### PR TITLE
Phase 16: close estimator shadow and replay validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Python syntax validation
         shell: bash
-        run: python3 -m py_compile tests/__init__.py tests/test_dashboard_backend_status.py main.py scripts/generate_firmware_manifest.py scripts/drone_setup.py scripts/bench_check.py scripts/local_validate.py scripts/generate_tls_certs.py scripts/pre_arm_check.py scripts/production_telemetry_smoke_test.py scripts/telemetry_smoke_test.py gui/dashboard.py gui/backend_status.py gui/operator_console.py
+        run: python3 -m py_compile tests/__init__.py tests/test_dashboard_backend_status.py main.py scripts/generate_firmware_manifest.py scripts/drone_setup.py scripts/bench_check.py scripts/local_validate.py scripts/generate_tls_certs.py scripts/pre_arm_check.py scripts/production_telemetry_smoke_test.py scripts/telemetry_smoke_test.py scripts/phase15_estimator_replay.py gui/dashboard.py gui/backend_status.py gui/operator_console.py
 
       - name: Python unit tests with coverage
         shell: bash
@@ -171,12 +171,29 @@ jobs:
           python3 -m coverage report | tee "${RUNNER_TEMP}/python-coverage/coverage.txt"
           python3 -m coverage xml -o "${RUNNER_TEMP}/python-coverage/coverage.xml"
 
+      - name: Deterministic estimator replay baseline
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p "${RUNNER_TEMP}/phase15-estimator"
+          python3 scripts/phase15_estimator_replay.py \
+            --input datasets/estimator/phase15_stationary_replay.json \
+            --output "${RUNNER_TEMP}/phase15-estimator/replay_report.json"
+
       - name: Upload Python coverage
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: python-coverage-${{ github.sha }}
           path: ${{ runner.temp }}/python-coverage
+          retention-days: 14
+
+      - name: Upload estimator replay report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: phase15-estimator-replay-${{ github.sha }}
+          path: ${{ runner.temp }}/phase15-estimator
           retention-days: 14
 
   go-ci:
@@ -254,12 +271,31 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/ctest-linux-gcc-validation"
           ctest --preset validation-linux-gcc --output-on-failure --output-junit "${RUNNER_TEMP}/ctest-linux-gcc-validation/junit.xml"
 
+      - name: Native replay and benchmark smoke
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p "${RUNNER_TEMP}/phase16-estimator"
+          build_dir="build/validation-linux-gcc"
+          "${build_dir}/tools/Release/estimator_replay_runner" \
+            --input datasets/estimator/phase15_stationary_replay.json \
+            --output "${RUNNER_TEMP}/phase16-estimator/replay_active.json" \
+            --mode active_only
+          "${build_dir}/tools/Release/estimator_replay_runner" \
+            --input datasets/estimator/phase15_stationary_replay.json \
+            --output "${RUNNER_TEMP}/phase16-estimator/replay_shadow.json" \
+            --mode active_with_identical_shadow
+          "${build_dir}/tools/Release/estimator_shadow_benchmark" \
+            --output "${RUNNER_TEMP}/phase16-estimator/benchmark.json"
+
       - name: Upload Linux GCC reports
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: ctest-linux-gcc-validation-${{ github.sha }}
-          path: ${{ runner.temp }}/ctest-linux-gcc-validation
+          path: |
+            ${{ runner.temp }}/ctest-linux-gcc-validation
+            ${{ runner.temp }}/phase16-estimator
           retention-days: 14
 
   linux-gcc-debug:
@@ -450,12 +486,33 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\ctest-windows-msvc-validation" | Out-Null
           ctest --preset validation-msvc --parallel 2 --output-on-failure --output-junit "$env:RUNNER_TEMP\ctest-windows-msvc-validation\junit.xml"
 
+      - name: Native replay and benchmark smoke
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\phase16-estimator" | Out-Null
+          $buildDir = "build/validation-msvc"
+          & "$buildDir/tools/Release/estimator_replay_runner.exe" `
+            --input "datasets/estimator/phase15_stationary_replay.json" `
+            --output "$env:RUNNER_TEMP\phase16-estimator\replay_active.json" `
+            --mode active_only
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & "$buildDir/tools/Release/estimator_replay_runner.exe" `
+            --input "datasets/estimator/phase15_stationary_replay.json" `
+            --output "$env:RUNNER_TEMP\phase16-estimator\replay_shadow.json" `
+            --mode active_with_identical_shadow
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & "$buildDir/tools/Release/estimator_shadow_benchmark.exe" `
+            --output "$env:RUNNER_TEMP\phase16-estimator\benchmark.json"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload Windows validation reports
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: ctest-windows-msvc-validation-${{ github.sha }}
-          path: ${{ runner.temp }}\ctest-windows-msvc-validation
+          path: |
+            ${{ runner.temp }}\ctest-windows-msvc-validation
+            ${{ runner.temp }}\phase16-estimator
           if-no-files-found: ignore
           retention-days: 14
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(DRONE_ENABLE_ASAN "Enable AddressSanitizer on supported toolchains" OFF)
 option(DRONE_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer on supported toolchains" OFF)
 option(DRONE_ENABLE_COVERAGE "Enable native coverage instrumentation on supported toolchains" OFF)
 option(DRONE_ENABLE_CPACK "Enable archive packaging via CPack" OFF)
+option(DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW "Enable phase 16 shadow-estimator plumbing" ON)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -74,6 +75,7 @@ function(drone_append_build_interface_paths out_var)
 endfunction()
 
 drone_resolve_dependencies()
+drone_enable_nlohmann_json()
 
 drone_append_build_interface_paths(DRONE_OPENCV_BUILD_INCLUDE_DIRS ${DRONE_OPENCV_INCLUDE_DIRS})
 drone_append_build_interface_paths(DRONE_PCL_BUILD_INCLUDE_DIRS ${DRONE_PCL_INCLUDE_DIRS})
@@ -92,6 +94,10 @@ set(DRONE_CORE_SOURCES
     src/localization/TimeSyncTracker.cpp
     src/localization/UWBSerialDriver.cpp
     src/runtime/RuntimeMode.cpp
+    src/estimation/EstimatorComparison.cpp
+    src/estimation/EstimatorCoordinator.cpp
+    src/estimation/MeasurementAdapters.cpp
+    src/estimation/MinimalEskfAdapter.cpp
     src/security/PeerPacketAuth.cpp
     src/swarm/EdgeConsensusManager.cpp
     src/swarm/EdgePeerProtocol.cpp
@@ -114,6 +120,16 @@ set(DRONE_CORE_SOURCES
     src/hal/JetsonHAL.cpp
     src/swarm/V2XMeshNetwork.cpp
     third_party/crypto/monocypher.c
+    third_party/crypto/sha3.c
+)
+
+set(DRONE_ESTIMATOR_CORE_SOURCES
+    src/estimation/EstimatorComparison.cpp
+    src/estimation/EstimatorCoordinator.cpp
+    src/estimation/MeasurementAdapters.cpp
+    src/estimation/MinimalEskfAdapter.cpp
+    src/runtime/RuntimeMode.cpp
+    src/vio/EKFEstimator.cpp
     third_party/crypto/sha3.c
 )
 
@@ -153,6 +169,7 @@ target_compile_definitions(sensor_fusion_core
     PUBLIC
         $<$<BOOL:${DRONE_HAVE_FASTDDS_TRANSPORT}>:DRONE_HAS_FASTDDS_TRANSPORT>
         $<$<BOOL:${DRONE_HAVE_TENSORRT}>:DRONE_HAS_TENSORRT>
+        $<$<BOOL:${DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW}>:DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW>
         ${DRONE_PCL_COMPILE_DEFINITIONS}
 )
 drone_apply_project_warnings(sensor_fusion_core)
@@ -160,12 +177,70 @@ drone_enable_coverage(sensor_fusion_core)
 drone_enable_sanitizers(sensor_fusion_core)
 drone_set_target_output_dirs(sensor_fusion_core "bin" "lib" "lib")
 
+add_library(estimator_validation_core STATIC)
+target_sources(estimator_validation_core PRIVATE ${DRONE_ESTIMATOR_CORE_SOURCES})
+target_compile_features(estimator_validation_core PUBLIC cxx_std_20)
+set_target_properties(estimator_validation_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(estimator_validation_core
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/crypto>
+)
+target_link_libraries(estimator_validation_core
+    PUBLIC
+        Eigen3::Eigen
+        Threads::Threads
+        spdlog::spdlog
+)
+target_compile_definitions(estimator_validation_core
+    PUBLIC
+        $<$<BOOL:${DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW}>:DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW>
+)
+drone_apply_project_warnings(estimator_validation_core)
+drone_enable_coverage(estimator_validation_core)
+drone_enable_sanitizers(estimator_validation_core)
+drone_set_target_output_dirs(estimator_validation_core "bin" "lib" "lib")
+
+add_library(estimator_replay_support STATIC
+    src/estimation/ReplayRunner.cpp
+)
+target_link_libraries(estimator_replay_support
+    PUBLIC
+        estimator_validation_core
+        nlohmann_json::nlohmann_json
+)
+target_include_directories(estimator_replay_support
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+drone_apply_project_warnings(estimator_replay_support)
+drone_enable_coverage(estimator_replay_support)
+drone_enable_sanitizers(estimator_replay_support)
+drone_set_target_output_dirs(estimator_replay_support "bin" "lib" "lib")
+
 add_executable(drone_node src/main.cpp)
 target_link_libraries(drone_node PRIVATE sensor_fusion_core)
 drone_apply_project_warnings(drone_node)
 drone_enable_coverage(drone_node)
 drone_enable_sanitizers(drone_node)
 drone_set_target_output_dirs(drone_node "bin" "lib" "lib")
+
+add_executable(estimator_replay_runner tools/estimator_replay_runner.cpp)
+target_link_libraries(estimator_replay_runner PRIVATE estimator_replay_support)
+drone_apply_project_warnings(estimator_replay_runner)
+drone_enable_coverage(estimator_replay_runner)
+drone_enable_sanitizers(estimator_replay_runner)
+drone_set_target_output_dirs(estimator_replay_runner "tools" "tools" "tools")
+
+add_executable(estimator_shadow_benchmark tools/estimator_shadow_benchmark.cpp)
+target_link_libraries(estimator_shadow_benchmark PRIVATE
+    estimator_validation_core
+    nlohmann_json::nlohmann_json
+)
+drone_apply_project_warnings(estimator_shadow_benchmark)
+drone_enable_coverage(estimator_shadow_benchmark)
+drone_enable_sanitizers(estimator_shadow_benchmark)
+drone_set_target_output_dirs(estimator_shadow_benchmark "tools" "tools" "tools")
 
 if(DRONE_ENABLE_PYTHON_BINDINGS AND DRONE_HAVE_PYTHON_BINDINGS)
     pybind11_add_module(drone_bridge src/drone_bridge.cpp)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -17,6 +17,36 @@ set(DRONE_HAVE_PYTHON_BINDINGS FALSE)
 set(DRONE_FASTDDS_STATUS "DISABLED")
 set(DRONE_TENSORRT_STATUS "DISABLED")
 set(DRONE_PYTHON_BINDINGS_STATUS "DISABLED")
+set(DRONE_HAVE_NLOHMANN_JSON FALSE)
+
+function(drone_enable_nlohmann_json)
+    if(TARGET nlohmann_json::nlohmann_json)
+        set(DRONE_HAVE_NLOHMANN_JSON TRUE PARENT_SCOPE)
+        return()
+    endif()
+
+    find_package(nlohmann_json CONFIG QUIET)
+    if(TARGET nlohmann_json::nlohmann_json)
+        set(DRONE_HAVE_NLOHMANN_JSON TRUE PARENT_SCOPE)
+        message(STATUS "nlohmann_json: FOUND - package config mode")
+        return()
+    endif()
+
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+    if(TARGET nlohmann_json::nlohmann_json)
+        set(DRONE_HAVE_NLOHMANN_JSON TRUE PARENT_SCOPE)
+        message(STATUS "nlohmann_json: FETCHED - FetchContent fallback enabled")
+        return()
+    endif()
+
+    message(FATAL_ERROR "nlohmann_json is required for replay tooling but could not be resolved.")
+endfunction()
 
 function(drone_enable_googletest)
     if(TARGET GTest::gtest_main)

--- a/config/runtime.example.json
+++ b/config/runtime.example.json
@@ -20,6 +20,29 @@
     "safety_manager_enabled": true,
     "simulation_fallback_enabled": false,
     "pre_arm_required": true,
-    "bench_validation_required": true
+    "bench_validation_required": true,
+    "estimator": {
+      "mode": "minimal",
+      "enable_experimental_hybrid": false,
+      "enable_fej": false,
+      "enable_msckf": false,
+      "enable_loop_closure_correction": false,
+      "enable_automatic_zupt": false,
+      "shadow": {
+        "enabled": false,
+        "comparison_enabled": true,
+        "implementation": "minimal_eskf_clone",
+        "max_queue_depth": 512,
+        "max_lag_ms": 100.0,
+        "position_divergence_m": 0.25,
+        "velocity_divergence_mps": 0.2,
+        "orientation_divergence_deg": 5.0,
+        "required_consecutive_divergent_samples": 10
+      },
+      "reject_non_finite_measurements": true,
+      "require_monotonic_timestamps": true,
+      "max_imu_dt_s": 0.1,
+      "diagnostics_enabled": true
+    }
   }
 }

--- a/config/runtime.json
+++ b/config/runtime.json
@@ -21,6 +21,18 @@
     "simulation_fallback_enabled": false,
     "pre_arm_required": true,
     "bench_validation_required": true,
+    "estimator": {
+      "mode": "minimal",
+      "enable_experimental_hybrid": false,
+      "enable_fej": false,
+      "enable_msckf": false,
+      "enable_loop_closure_correction": false,
+      "enable_automatic_zupt": false,
+      "reject_non_finite_measurements": true,
+      "require_monotonic_timestamps": true,
+      "max_imu_dt_s": 0.1,
+      "diagnostics_enabled": true
+    },
     "edge_swarm_defaults": {
       "mesh_topology_mode": "adaptive_mesh",
       "peer_sync_interval_ms": 100,

--- a/datasets/estimator/phase15_stationary_replay.json
+++ b/datasets/estimator/phase15_stationary_replay.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "scenario": "stationary_bias_free_baseline",
+  "initial_state": {
+    "position": [0.0, 0.0, 0.0],
+    "velocity": [0.0, 0.0, 0.0],
+    "yaw_rad": 0.0
+  },
+  "records": [
+    {
+      "type": "imu",
+      "timestamp_s": 0.01,
+      "accel_mps2": [0.0, 0.0, 9.81],
+      "gyro_rads": [0.0, 0.0, 0.0]
+    },
+    {
+      "type": "imu",
+      "timestamp_s": 0.02,
+      "accel_mps2": [0.0, 0.0, 9.81],
+      "gyro_rads": [0.0, 0.0, 0.0]
+    },
+    {
+      "type": "depth",
+      "timestamp_s": 0.03,
+      "z_world_m": 0.02,
+      "sigma_m": 0.05
+    },
+    {
+      "type": "visual_pose",
+      "timestamp_s": 0.04,
+      "position_m": [0.01, 0.0, 0.02],
+      "velocity_mps": [0.0, 0.0, 0.0],
+      "sigma_position_m": 0.2,
+      "sigma_velocity_mps": 0.2
+    },
+    {
+      "type": "ground_truth",
+      "timestamp_s": 0.05,
+      "position_m": [0.01, 0.0, 0.02],
+      "velocity_mps": [0.0, 0.0, 0.0],
+      "yaw_rad": 0.0
+    }
+  ]
+}

--- a/docs/phase15/ESTIMATOR_BASELINE.md
+++ b/docs/phase15/ESTIMATOR_BASELINE.md
@@ -1,0 +1,19 @@
+# Estimator Baseline
+
+The Phase 15 baseline keeps the existing real-time ESKF active while adding deterministic validation hooks around it.
+
+## Baseline protections
+
+- IMU propagation rejects non-finite values, backward timestamps, and `dt` values above the configured bound.
+- Measurement corrections use LDLT solves plus Joseph-form covariance updates.
+- Covariance is symmetrized and bounded after propagation and correction.
+- Diagnostics expose accepted/rejected updates, invalid input counts, timestamp violations, covariance metrics, and health state.
+- The active LiDAR height correction is disabled until its frame semantics are observable and explicitly calibrated.
+
+## Drift semantics
+
+`drift_m` remains available for compatibility, but in the current implementation it represents estimated position uncertainty derived from covariance, not measured drift against ground truth.
+
+## Visual orientation
+
+The frontend currently produces relative orientation estimates, but Phase 15 does not feed them into the EKF update. That behavior is intentional until a bounded orientation-aware interface is introduced in a later phase.

--- a/docs/phase15/ESTIMATOR_INVARIANTS.md
+++ b/docs/phase15/ESTIMATOR_INVARIANTS.md
@@ -1,0 +1,11 @@
+# Estimator Invariants
+
+- The quaternion must remain normalized.
+- Covariance must remain finite and symmetric.
+- Invalid measurements must not modify the estimator state.
+- Timestamps must not move backwards.
+- Measurement corrections must remain bounded.
+- The estimator must never output NaN or infinity.
+- Experimental estimators must not control navigation.
+- Loop closure must not directly hard-reset the local estimator.
+- Software validation evidence does not imply flight safety.

--- a/docs/phase15/PHASE15_PLAN.md
+++ b/docs/phase15/PHASE15_PLAN.md
@@ -1,0 +1,23 @@
+# Phase 15 Plan
+
+Phase 15 establishes a deterministic correctness baseline for the current minimal ESKF without enabling FEJ, MSCKF, automatic ZUPT, or loop-closure corrections.
+
+## Scope
+
+- Keep the active 16-state nominal and 15-state error formulation unchanged.
+- Harden estimator inputs, covariance updates, and timestamp handling.
+- Expose lightweight diagnostics and deterministic replay tooling.
+- Preserve runtime mode behavior and fail closed on unsupported experimental estimator settings.
+
+## Confirmed code issues
+
+- The LiDAR path in `src/vio/VIOPipeline.cpp` computed a ground-relative height and then fed `pose.position.z()` back into `update_depth()`, creating covariance reduction without independent information.
+- `update_depth()` and `update_zupt()` used subtractive covariance updates instead of the Joseph form.
+- The visual frontend computes `relative_orientation`, but the EKF correction path only consumes position and velocity.
+- `drift_m` semantics reflected estimated position uncertainty, not measured trajectory drift against ground truth.
+
+## Phase boundary
+
+- Experimental hybrid estimator components remain disabled.
+- The current minimal ESKF remains the only active estimator output.
+- Phase 15 software validation does not imply hardware or flight safety.

--- a/docs/phase15/PHASE15_VALIDATION_REPORT.md
+++ b/docs/phase15/PHASE15_VALIDATION_REPORT.md
@@ -1,0 +1,24 @@
+# Phase 15 Validation Report
+
+## Validation status
+
+Phase 15 validation was executed on July 17, 2026 in the local development environment. This report covers software-only evidence and does not claim hardware or flight validation.
+
+## Commands executed
+
+- `cmake --preset validation-msvc -DDRONE_ENABLE_PYTHON_BINDINGS=OFF`
+- `cmake --build --preset validation-msvc --target test_ekf test_navigation_intelligence --parallel`
+- `ctest --test-dir build/validation-msvc -C Release --output-on-failure -R "EKFTest|LocalizationFusion|RuntimeMode"`
+- `python -m py_compile scripts/phase15_estimator_replay.py`
+- `python -m black scripts/phase15_estimator_replay.py`
+- `python scripts/phase15_estimator_replay.py --input datasets/estimator/phase15_stationary_replay.json --output artifacts/phase15_estimator_replay_report.json`
+- `build\validation-msvc\tests\Release\test_ekf.exe --gtest_filter=EKFTest.DepthUpdateCorrection:EKFTest.ZUPTClearsVelocity:EKFTest.ZuptPreservesPositionAttitudeAndBiases`
+- `build\validation-msvc\tests\Release\test_navigation_intelligence.exe --gtest_filter=LocalizationFusion.RejectsNonFiniteTdoaInput`
+
+## Summary
+
+- The estimator baseline now rejects non-finite inputs and timestamp violations.
+- The ambiguous LiDAR depth update is disabled instead of silently shrinking covariance.
+- Diagnostics and replay tooling are present for deterministic software validation.
+- The focused native validation slice passed in full: 36 of 36 `EKFTest`, `LocalizationFusion`, and `RuntimeMode` cases passed on July 17, 2026.
+- The deterministic replay artifact was generated at `artifacts/phase15_estimator_replay_report.json` with replay hash `ac6205282a71044d6434eced9ebe6c6c8710846204f47b43d4dbd62757a694a0`.

--- a/docs/phase16/CI_EVIDENCE.md
+++ b/docs/phase16/CI_EVIDENCE.md
@@ -1,0 +1,46 @@
+# CI Evidence
+
+## Date
+
+Friday, July 17, 2026
+
+## Local workflow validation
+
+The following local workflow validation was executed:
+
+- `actionlint`
+- `python scripts/audit_workflows.py`
+
+Both passed locally in this session lineage.
+
+## Hosted GitHub Actions status
+
+No hosted GitHub Actions run was executed from this session.
+
+Blocked items:
+
+- no authenticated `gh` CLI session
+- no authenticated push from this session
+- no branch creation from this session
+- no pull request creation from this session
+- no workflow dispatch or PR-triggered hosted run from this session
+- no hosted artifact download or verification from this session
+
+## Evidence we do have
+
+- workflow YAML exists in `.github/workflows/ci.yml`
+- local workflow linting passed
+- local workflow audit passed
+
+## Evidence we do not have
+
+- workflow run IDs
+- workflow URLs
+- hosted job logs
+- hosted uploaded artifacts
+- hosted artifact integrity checks
+
+## Honest status
+
+Phase 16 local software evidence is strong.
+Phase 16 hosted CI evidence remains `NOT RUN` from this session and must not be claimed as complete without authenticated GitHub execution.

--- a/docs/phase16/ESTIMATOR_INTERFACE.md
+++ b/docs/phase16/ESTIMATOR_INTERFACE.md
@@ -1,0 +1,31 @@
+# Estimator Interface
+
+## Added types
+
+- `drone::estimation::StateEstimator`
+- `EstimatorInitialState`
+- `EstimatorUpdateResult`
+- `EstimatorSnapshot`
+- `EstimatorCapabilities`
+
+## Current production-backed implementation
+
+`MinimalEskfAdapter` delegates to the existing `drone::vio::EKFEstimator` and does not duplicate estimator mathematics.
+
+## Capability reporting
+
+The adapter reports only capabilities that are currently implemented:
+
+- IMU propagation
+- Visual position update
+- Visual velocity update
+- Depth update
+- Zero-velocity update
+
+It does not report:
+
+- Visual orientation fusion
+- TDOA update
+- Loop-closure correction
+- FEJ
+- MSCKF

--- a/docs/phase16/MEASUREMENT_ADAPTERS.md
+++ b/docs/phase16/MEASUREMENT_ADAPTERS.md
@@ -1,0 +1,35 @@
+# Measurement Adapters
+
+## Envelope
+
+`EstimatorMeasurement` carries:
+
+- timestamp
+- sequence id
+- sensor source
+- coordinate frame
+- measurement type
+- typed payload
+
+## Adapter status model
+
+- `ACCEPTED`
+- `REJECTED_INVALID`
+- `REJECTED_STALE`
+- `REJECTED_UNSUPPORTED`
+- `REJECTED_FRAME_MISMATCH`
+- `REJECTED_OUTLIER`
+- `IGNORED_SHADOW_ONLY`
+
+## Implemented adapters
+
+- IMU
+- Visual pose and velocity
+- Visual orientation metadata transport
+- Manual ZUPT
+- Altitude/depth envelope
+- TDOA position candidate tagging
+
+## Phase 16 limitation
+
+Visual orientation is preserved in the envelope but intentionally not consumed by the active minimal ESKF.

--- a/docs/phase16/NATIVE_REPLAY.md
+++ b/docs/phase16/NATIVE_REPLAY.md
@@ -1,0 +1,103 @@
+# Native Replay
+
+## Status
+
+Implemented in Phase 16B and re-validated during Phase 16D on the estimator-only validation path:
+
+`EstimatorMeasurement -> MinimalEskfAdapter -> optional EstimatorCoordinator shadow path -> EKFEstimator`
+
+## Supported modes
+
+- `active_only`
+- `active_with_identical_shadow`
+
+The identical-shadow mode runs a separate minimal ESKF instance and never promotes shadow output to the authoritative pose.
+
+## Input schema
+
+Replay input currently requires:
+
+- `schema_version = 1`
+- `coordinate_frame`
+- optional `initial_state`
+- ordered `records`
+
+Supported record types:
+
+- `imu`
+- `visual_pose`
+- `depth`
+- `altitude`
+- `zupt`
+- `tdoa_candidate`
+
+`ground_truth` may appear as metadata, but it is not fused.
+Visual orientation may be present on `visual_pose`, is transported through the envelope, and remains unfused by `MinimalEskfAdapter`.
+
+## Safety limits
+
+Replay input is treated as untrusted and validated for:
+
+- maximum file size
+- maximum record count
+- maximum string length
+- supported schema version
+- finite numeric values
+- strictly monotonic timestamps
+- supported coordinate frame
+- positive covariance or sigma values
+- normalizable quaternion input
+- bounded vector dimensions
+- non-zero exit status on failure
+
+## Output report
+
+`estimator_replay_runner` emits machine-readable JSON including:
+
+- input and report schema versions
+- replay mode
+- estimator names
+- processed, accepted, rejected, invalid and unsupported counts
+- final state and uncertainty
+- active and shadow health
+- active versus shadow deltas
+- queue and synchronization telemetry
+- deterministic result hash
+- average and maximum propagation/update latencies
+- success flag and failure reason
+
+## Deterministic hash
+
+The replay hash is derived from a canonical text payload built from meaningful report fields only.
+It does not include raw memory, struct padding, or transient timing-only values.
+Floating-point values are normalized with fixed decimal formatting to 12 digits after the decimal point.
+
+Determinism is only claimed for the same input, build, executable, platform, and relevant runtime configuration.
+
+Across local MSVC, GCC, and Clang validation, the final replay state matched on the Phase 15 stationary dataset while deterministic hashes remained mode-specific artifacts rather than a cross-compiler equality guarantee.
+
+## Example commands
+
+```powershell
+.\build\validation-msvc\tools\Release\estimator_replay_runner.exe `
+  --input datasets\estimator\phase15_stationary_replay.json `
+  --output artifacts\phase16_replay_active.json `
+  --mode active_only
+```
+
+```bash
+./build/validation-linux-gcc/tools/Release/estimator_replay_runner \
+  --input datasets/estimator/phase15_stationary_replay.json \
+  --output artifacts/phase16_replay_shadow.json \
+  --mode active_with_identical_shadow
+```
+
+## Current validation note
+
+The replay path was re-executed during Phase 16D under the isolated local ThreadSanitizer lane using the same stationary replay fixture.
+
+## Limitations
+
+- Native replay currently covers only the safe measurement subset listed above.
+- Unsupported experimental estimator features remain fail-closed.
+- Software replay evidence is not flight evidence.

--- a/docs/phase16/PERFORMANCE_BASELINE.md
+++ b/docs/phase16/PERFORMANCE_BASELINE.md
@@ -1,0 +1,99 @@
+# Performance Baseline
+
+## Scope
+
+This document records software-only Phase 16 benchmark evidence gathered on Friday, July 17, 2026.
+It does not claim hard real-time guarantees, hardware safety, or flight readiness.
+
+## Benchmark tool
+
+Target:
+
+- `estimator_shadow_benchmark`
+
+Scenarios:
+
+- `active_only`
+- `active_with_shadow`
+- `shadow_overload`
+
+Primary Phase 16D aggregate artifacts:
+
+- `artifacts/phase16d_benchmark_aggregate.json`
+- `artifacts/phase16d_benchmark_summary.md`
+
+Earlier single-run cross-toolchain artifacts remain available for historical context:
+
+- `artifacts/phase16c_gcc_benchmark.json`
+- `artifacts/phase16c_clang_benchmark.json`
+- `artifacts/phase16c_gcc_asan_benchmark.json`
+- `artifacts/phase16c_clang_asan_benchmark.json`
+
+## Repeated-run methodology
+
+The current methodology uses deterministic randomized repeated runs with seed `16016`:
+
+- `active_only`: 10 runs
+- `active_with_shadow`: 10 runs
+- `shadow_overload`: 5 runs
+
+Per run:
+
+- warm-up iterations: `250`
+- measured iterations: `2000`
+
+The `active_with_shadow` scenario now waits for shadow drain on each iteration so it measures a nominal synchronized shadow path instead of an accidental overload case.
+
+## Aggregate environment
+
+- Operating system: Linux
+- Compiler: GCC 15.2.0
+- Build type: Release
+- CPU: 12th Gen Intel(R) Core(TM) i5-12400F
+- Timer source: `std::chrono::steady_clock`
+
+## Aggregate results
+
+### Active only
+
+- Mean of run means: `3.035 us`
+- Median of run means: `3.004 us`
+- Aggregate median: `2.804 us`
+- Aggregate p95: `4.522 us`
+- Aggregate p99: `5.370 us`
+- Worst maximum latency: `215.220 us`
+- Dropped events: `0`
+- Final shadow healths: `disabled`
+
+### Active with shadow
+
+- Mean of run means: `13.522 us`
+- Median of run means: `13.342 us`
+- Aggregate median: `12.183 us`
+- Aggregate p95: `19.610 us`
+- Aggregate p99: `29.497 us`
+- Worst maximum latency: `174.786 us`
+- Dropped events: `0`
+- Maximum queue high-water mark: `3`
+- Final shadow healths: `synchronized`
+- Active output matched baseline in all runs: `true`
+
+### Shadow overload
+
+- Mean of run means: `3.819 us`
+- Median of run means: `3.897 us`
+- Aggregate median: `2.924 us`
+- Aggregate p95: `5.663 us`
+- Aggregate p99: `11.674 us`
+- Worst maximum latency: `121.168 us`
+- Dropped events: `11951`
+- Maximum queue high-water mark: `8`
+- Final shadow healths: `stale`
+- Active output matched baseline in all runs: `true`
+
+## Interpretation
+
+- The nominal shadow mode stayed synchronized without drops in the repeated aggregate.
+- The overload scenario dropped events and became stale while keeping queue growth bounded.
+- Active-output equivalence held across all repeated runs.
+- The benchmark is useful for regression detection, not for universal timing guarantees.

--- a/docs/phase16/PHASE16_PLAN.md
+++ b/docs/phase16/PHASE16_PLAN.md
@@ -1,0 +1,36 @@
+# Phase 16 Plan
+
+## Scope implemented in Phase 16
+
+- Stable `StateEstimator` interface
+- `MinimalEskfAdapter` around the existing `EKFEstimator`
+- Standardized typed measurement envelope and validation status model
+- Bounded shadow-estimator coordinator and comparison telemetry
+- Fail-closed runtime configuration for unsupported active hybrid mode
+- Native C++ replay runner
+- Local cross-toolchain replay validation on MSVC, GCC, and Clang
+- Local ASan+UBSan validation on GCC and Clang
+- Repeated benchmark aggregation for nominal and overload shadow scenarios
+- Isolated representative TSan validation on estimator-only targets
+
+## Explicitly not implemented here
+
+- FEJ
+- MSCKF
+- Active visual-orientation fusion
+- Automatic ZUPT
+- Loop-closure correction into estimator state
+- Hosted GitHub Actions evidence from this session
+
+## Safety invariants preserved
+
+1. The minimal ESKF remains the only authoritative estimator.
+2. Shadow processing is best-effort and non-blocking for the active path.
+3. Shadow queueing is bounded and exposes drop telemetry.
+4. Unsupported estimator modes fail closed.
+5. Visual orientation metadata is transported but not fused.
+
+## Closure note
+
+Phase 16 local software evidence is now materially stronger than the original implementation checkpoint.
+Remaining closure work, if required, is operational rather than architectural: authenticated hosted CI execution and artifact verification.

--- a/docs/phase16/PHASE16_VALIDATION_REPORT.md
+++ b/docs/phase16/PHASE16_VALIDATION_REPORT.md
@@ -1,0 +1,90 @@
+# Phase 16 Validation Report
+
+## Date
+
+Friday, July 17, 2026
+
+## Status summary
+
+Phase 16 local software evidence is substantially complete.
+Hosted GitHub Actions evidence was not executed from this session because no authenticated GitHub session was available.
+
+## Prior evidence re-verified in this session
+
+The following evidence existed before Phase 16D closure work and remains valid:
+
+- Windows MSVC Release replay and shadow validation passed locally.
+- Linux GCC Release CTest passed: `164/164`.
+- Linux Clang Release CTest passed: `164/164`.
+- Linux GCC ASan+UBSan CTest passed: `164/164`.
+- Linux Clang ASan+UBSan CTest passed: `164/164`.
+- Replay active-only and active-with-identical-shadow succeeded locally on MSVC, GCC, Clang, GCC ASan+UBSan, and Clang ASan+UBSan.
+- `actionlint` passed locally.
+- `python scripts/audit_workflows.py` passed locally.
+
+## New evidence executed in this session
+
+The following work was executed locally on Friday, July 17, 2026:
+
+- Focused Linux GCC rebuild of estimator-only validation targets through `validation-linux-gcc`.
+- Focused local rerun of `test_estimator_shadow`.
+- Focused local rerun of `test_estimator_replay`.
+- New repeated benchmark aggregation via `scripts/phase16_benchmark_aggregate.py`.
+- Focused local ThreadSanitizer rerun on estimator-only targets in `build/linux-clang-tsan`.
+
+## Current local validation matrix
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| MSVC replay and shadow validation | PASS | Prior local evidence |
+| GCC Release full test suite | PASS | Prior local evidence (`164/164`) |
+| Clang Release full test suite | PASS | Prior local evidence (`164/164`) |
+| GCC ASan+UBSan full test suite | PASS | Prior local evidence (`164/164`) |
+| Clang ASan+UBSan full test suite | PASS | Prior local evidence (`164/164`) |
+| Focused estimator replay test rerun | PASS | `test_estimator_replay` |
+| Focused estimator shadow test rerun | PASS | `test_estimator_shadow` |
+| Repeated benchmark aggregation | PASS | `artifacts/phase16d_benchmark_aggregate.json` |
+| Isolated TSan estimator replay test | PASS | `test_estimator_replay` |
+| Isolated TSan estimator shadow test | PASS | `test_estimator_shadow` |
+| Isolated TSan replay runner | PASS | `artifacts/phase16d_tsan_replay_active.json` |
+| Isolated TSan shadow benchmark | PASS | `artifacts/phase16d_tsan_shadow_benchmark.json` |
+| GitHub-hosted CI run from this session | NOT RUN | No GitHub authentication |
+
+## TSan outcome
+
+Phase 16C TSan evidence was previously partial because representative replay targets still encountered third-party OpenNI startup warnings.
+
+Phase 16D isolated the replay, shadow test, and benchmark targets onto an estimator-only linkage path so they no longer require the broader sensor-fusion stack for this validation lane.
+After that isolation:
+
+- `test_estimator_replay` passed under TSan.
+- `test_estimator_shadow` passed under TSan.
+- `estimator_replay_runner` completed successfully under TSan on `datasets/estimator/phase15_stationary_replay.json`.
+- `estimator_shadow_benchmark` completed successfully under TSan after fixing one tool-local race in benchmark latency bookkeeping.
+
+No third-party OpenNI startup warning reappeared on these isolated Phase 16 estimator targets.
+
+## Repeated benchmark outcome
+
+The benchmark methodology now uses deterministic randomized repeated runs with warm-up separation:
+
+- `active_only`: 10 runs
+- `active_with_shadow`: 10 runs
+- `shadow_overload`: 5 runs
+
+Current aggregate results are documented in `PERFORMANCE_BASELINE.md` and emitted to:
+
+- `artifacts/phase16d_benchmark_aggregate.json`
+- `artifacts/phase16d_benchmark_summary.md`
+
+## Hosted CI status
+
+Workflow files were linted locally, but no GitHub-hosted Actions run, branch push, pull request, or artifact download was completed from this session.
+See `CI_EVIDENCE.md` for the explicit hosted-evidence status.
+
+## Limits and honesty
+
+- Deterministic replay evidence is software evidence only.
+- Native replay and shadow validation do not imply flight readiness.
+- Benchmark results are environment-specific regression evidence, not universal timing guarantees.
+- Hosted CI evidence remains blocked on authentication rather than code correctness.

--- a/docs/phase16/SANITIZER_VALIDATION.md
+++ b/docs/phase16/SANITIZER_VALIDATION.md
@@ -1,0 +1,64 @@
+# Sanitizer Validation
+
+## Date
+
+Friday, July 17, 2026
+
+## Prior sanitizer evidence
+
+Before this closure pass:
+
+- Linux GCC ASan+UBSan full test suite passed locally.
+- Linux Clang ASan+UBSan full test suite passed locally.
+- A manual local Clang TSan lane existed, but representative replay targets still hit noisy third-party startup warnings from OpenNI-linked paths.
+
+## Phase 16D isolation change
+
+To make the estimator validation lane attributable, the replay, shadow test, and benchmark targets were moved onto an estimator-only linkage path:
+
+- `estimator_validation_core`
+- `estimator_replay_support`
+- `test_estimator_shadow`
+- `estimator_shadow_benchmark`
+
+This removed the need for the broader sensor-fusion linkage on the representative Phase 16 estimator targets used for TSan evidence.
+
+## TSan targets executed
+
+The following local targets were executed from `build/linux-clang-tsan`:
+
+- `tests/Debug/test_estimator_replay`
+- `tests/Debug/test_estimator_shadow`
+- `tools/Debug/estimator_replay_runner`
+- `tools/Debug/estimator_shadow_benchmark`
+
+## Result classification
+
+| Target | Result | Notes |
+| --- | --- | --- |
+| `test_estimator_replay` | PASS | No TSan finding observed |
+| `test_estimator_shadow` | PASS | No TSan finding observed |
+| `estimator_replay_runner` | PASS | Replay completed successfully on the Phase 15 stationary fixture |
+| `estimator_shadow_benchmark` | PASS after fix | Initial TSan run found a tool-local race in benchmark latency sampling |
+
+## Tool-local race fixed
+
+TSan initially reported a data race in `tools/estimator_shadow_benchmark.cpp`:
+
+- writer: shadow worker updated `last_processing_latency_us_`
+- reader: main thread sampled `last_processing_latency_us()`
+
+This was fixed by changing the latency field to `std::atomic<double>` and using relaxed load/store operations.
+
+## Third-party result
+
+For the isolated estimator-only Phase 16 targets executed in this session:
+
+- no OpenNI startup warning reappeared
+- no third-party TSan suppression file was used
+- no third-party TSan issue is currently blocking this estimator-validation lane
+
+## Remaining limitation
+
+This document covers the representative Phase 16 estimator validation path, not every binary in the repository.
+Other non-estimator binaries may still require separate sanitizer attribution if broader repository-wide TSan coverage is desired later.

--- a/docs/phase16/SHADOW_ESTIMATOR_ARCHITECTURE.md
+++ b/docs/phase16/SHADOW_ESTIMATOR_ARCHITECTURE.md
@@ -1,0 +1,62 @@
+# Shadow Estimator Architecture
+
+## Authoritative path
+
+The minimal ESKF remains the only authoritative estimator.
+
+Runtime sensor events flow through:
+
+`EstimatorMeasurement -> active MinimalEskfAdapter -> authoritative pose/diagnostics`
+
+## Shadow path
+
+When enabled, the coordinator creates a separate shadow estimator instance and routes copies of accepted measurements into a bounded asynchronous queue:
+
+`EstimatorMeasurement -> bounded shadow queue -> shadow worker -> comparison telemetry only`
+
+The shadow estimator:
+
+- has independent mutable estimator state
+- is reset independently from active construction
+- is reinitialized from the last active reset state when configured
+- cannot publish authoritative vehicle pose
+- cannot switch or promote itself into the active role
+
+## Synchronization rules
+
+- Active processing completes before shadow work is awaited.
+- Queue depth is bounded by configuration.
+- Overflow drops the oldest shadow event and increments observable drop telemetry.
+- Queue history gaps invalidate synchronized comparison semantics.
+- Dropped events that later drain move the shadow status to `stale`.
+- Worker failures move the shadow status to `failed` without stopping active estimation.
+
+## Comparison telemetry
+
+`EstimatorComparison` reports:
+
+- active and shadow health
+- comparable versus skipped comparison counts
+- timestamp and sequence mismatch handling
+- position, velocity and orientation deltas
+- divergence state and last divergence reason
+
+Divergence only changes telemetry. It does not alter active confidence, does not switch estimators, and does not change the authoritative output source.
+
+## Validated behaviors
+
+Local Phase 16 validation now covers:
+
+- shadow-disabled active equivalence
+- active non-blocking behavior while shadow is delayed
+- queue overflow and stale transition
+- shadow worker failure containment
+- repeated configure and stop behavior
+- telemetry reads during concurrent processing
+- mismatched shadow history skipping comparison
+- shadow pose isolation from authoritative pose publication
+
+## Phase 16D validation-lane isolation
+
+Representative replay, shadow, and benchmark validation now also build against an estimator-only validation core for the focused sanitizer lane.
+That isolation keeps the authoritative and shadow estimator evidence attributable to Phase 16 code rather than unrelated sensor-fusion dependencies.

--- a/include/estimation/EstimatorComparison.hpp
+++ b/include/estimation/EstimatorComparison.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "estimation/StateEstimator.hpp"
+
+#include <string>
+
+namespace drone::estimation {
+
+enum class ShadowHealthState : uint8_t {
+    DISABLED = 0,
+    STARTING,
+    SYNCHRONIZED,
+    LAGGING,
+    STALE,
+    DIVERGED,
+    FAILED,
+    STOPPED,
+};
+
+struct ComparisonThresholds {
+    double max_timestamp_delta_s{0.02};
+    double position_divergence_m{0.25};
+    double velocity_divergence_mps{0.20};
+    double orientation_divergence_deg{5.0};
+    uint32_t required_consecutive_divergent_samples{10};
+};
+
+struct EstimatorComparisonSnapshot {
+    bool comparable{false};
+    double timestamp_delta_s{0.0};
+    double position_delta_m{0.0};
+    double velocity_delta_mps{0.0};
+    double orientation_delta_deg{0.0};
+    double accel_bias_delta{0.0};
+    double gyro_bias_delta{0.0};
+    double uncertainty_delta{0.0};
+    uint64_t comparable_snapshot_count{0};
+    uint64_t skipped_comparison_count{0};
+    uint32_t consecutive_divergent_samples{0};
+    bool diverged{false};
+    std::string last_divergence_reason{"none"};
+    ShadowHealthState shadow_health{ShadowHealthState::DISABLED};
+    drone::vio::EstimatorHealthState active_health{drone::vio::EstimatorHealthState::INITIALIZING};
+};
+
+class EstimatorComparison {
+public:
+    explicit EstimatorComparison(ComparisonThresholds thresholds = {});
+
+    [[nodiscard]] EstimatorComparisonSnapshot compare(const EstimatorSnapshot& active,
+                                                      const EstimatorSnapshot& shadow,
+                                                      ShadowHealthState shadow_health);
+
+private:
+    ComparisonThresholds thresholds_{};
+    EstimatorComparisonSnapshot latest_{};
+};
+
+} // namespace drone::estimation

--- a/include/estimation/EstimatorCoordinator.hpp
+++ b/include/estimation/EstimatorCoordinator.hpp
@@ -50,7 +50,8 @@ public:
     ~EstimatorCoordinator();
 
     void reset(const EstimatorInitialState& initial);
-    void configure_shadow(ShadowEstimatorConfig config, std::unique_ptr<StateEstimator> shadow_estimator);
+    void configure_shadow(ShadowEstimatorConfig config,
+                          std::unique_ptr<StateEstimator> shadow_estimator);
     void stop_shadow();
     [[nodiscard]] bool wait_for_shadow_idle(std::chrono::milliseconds timeout);
     [[nodiscard]] EstimatorUpdateResult process(const EstimatorMeasurement& measurement);

--- a/include/estimation/EstimatorCoordinator.hpp
+++ b/include/estimation/EstimatorCoordinator.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "estimation/EstimatorComparison.hpp"
+#include "estimation/StateEstimator.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <thread>
+#include <chrono>
+
+namespace drone::estimation {
+
+struct ShadowEstimatorConfig {
+    bool enabled{false};
+    bool comparison_enabled{true};
+    size_t max_queue_depth{512};
+    double max_lag_ms{100.0};
+    std::string implementation{"minimal_eskf_clone"};
+    ComparisonThresholds thresholds{};
+};
+
+struct ShadowEstimatorTelemetry {
+    bool enabled{false};
+    std::string active_estimator_name{"unknown"};
+    std::string shadow_estimator_name{"disabled"};
+    ShadowHealthState shadow_health{ShadowHealthState::DISABLED};
+    drone::vio::EstimatorHealthState active_health{drone::vio::EstimatorHealthState::INITIALIZING};
+    size_t queue_depth{0};
+    size_t queue_high_water_mark{0};
+    uint64_t dropped_events{0};
+    double lag_ms{0.0};
+    bool comparable{false};
+    double position_delta_m{0.0};
+    double velocity_delta_mps{0.0};
+    double orientation_delta_deg{0.0};
+    uint64_t comparable_snapshot_count{0};
+    uint64_t skipped_comparison_count{0};
+    std::string last_failure_reason{"none"};
+    std::string last_divergence_reason{"none"};
+    bool divergence_active{false};
+};
+
+class EstimatorCoordinator {
+public:
+    explicit EstimatorCoordinator(std::shared_ptr<StateEstimator> active_estimator);
+    ~EstimatorCoordinator();
+
+    void reset(const EstimatorInitialState& initial);
+    void configure_shadow(ShadowEstimatorConfig config, std::unique_ptr<StateEstimator> shadow_estimator);
+    void stop_shadow();
+    [[nodiscard]] bool wait_for_shadow_idle(std::chrono::milliseconds timeout);
+    [[nodiscard]] EstimatorUpdateResult process(const EstimatorMeasurement& measurement);
+    [[nodiscard]] EstimatorSnapshot active_snapshot() const;
+    [[nodiscard]] std::optional<EstimatorSnapshot> shadow_snapshot() const;
+    [[nodiscard]] ShadowEstimatorTelemetry telemetry() const;
+
+private:
+    struct QueuedMeasurement {
+        EstimatorMeasurement measurement{};
+        std::chrono::steady_clock::time_point enqueued_at{};
+    };
+
+    void worker_loop();
+    void update_shadow_telemetry_locked(const EstimatorComparisonSnapshot& comparison);
+
+    std::shared_ptr<StateEstimator> active_estimator_;
+    std::unique_ptr<StateEstimator> shadow_estimator_;
+    ShadowEstimatorConfig shadow_config_{};
+    EstimatorComparison comparison_{};
+
+    mutable std::mutex mutex_;
+    mutable std::mutex shadow_mutex_;
+    std::queue<QueuedMeasurement> shadow_queue_;
+    std::condition_variable shadow_cv_;
+    std::condition_variable shadow_idle_cv_;
+    std::thread shadow_thread_;
+    std::atomic<bool> stop_requested_{false};
+    size_t shadow_inflight_{0};
+    EstimatorInitialState last_initial_state_{};
+    bool has_initial_state_{false};
+    std::optional<EstimatorSnapshot> last_shadow_snapshot_;
+    ShadowEstimatorTelemetry telemetry_{};
+};
+
+} // namespace drone::estimation

--- a/include/estimation/EstimatorMeasurement.hpp
+++ b/include/estimation/EstimatorMeasurement.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace drone::estimation {
+
+enum class SensorSource : uint8_t {
+    UNKNOWN = 0,
+    IMU,
+    VISUAL_FRONTEND,
+    MANUAL_ZUPT,
+    DEPTH_SENSOR,
+    TDOA_HEURISTIC,
+};
+
+enum class CoordinateFrame : uint8_t {
+    UNKNOWN = 0,
+    BODY,
+    WORLD,
+    LOCAL_ENU,
+    SENSOR_LOCAL,
+};
+
+enum class MeasurementType : uint8_t {
+    IMU = 0,
+    VISUAL_POSE,
+    ALTITUDE,
+    ZERO_VELOCITY,
+    TDOA_POSITION_CANDIDATE,
+};
+
+enum class MeasurementValidationStatus : uint8_t {
+    ACCEPTED = 0,
+    REJECTED_INVALID,
+    REJECTED_STALE,
+    REJECTED_UNSUPPORTED,
+    REJECTED_FRAME_MISMATCH,
+    REJECTED_OUTLIER,
+    IGNORED_SHADOW_ONLY,
+};
+
+struct MeasurementCovariance {
+    Eigen::Matrix<double, 6, 6> matrix{Eigen::Matrix<double, 6, 6>::Zero()};
+    uint8_t dimension{0};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct MeasurementHeader {
+    double timestamp_s{0.0};
+    uint64_t sequence_id{0};
+    SensorSource source{SensorSource::UNKNOWN};
+    CoordinateFrame frame{CoordinateFrame::UNKNOWN};
+    MeasurementType type{MeasurementType::IMU};
+};
+
+struct ImuMeasurementData {
+    Eigen::Vector3d acceleration_mps2{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d angular_velocity_rads{Eigen::Vector3d::Zero()};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct VisualPoseMeasurementData {
+    Eigen::Vector3d position{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d velocity{Eigen::Vector3d::Zero()};
+    std::optional<Eigen::Quaterniond> orientation;
+    MeasurementCovariance covariance{};
+    double quality{0.0};
+    bool orientation_consumed{false};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct AltitudeMeasurementData {
+    double altitude_m{0.0};
+    double sigma_m{0.0};
+};
+
+struct ZeroVelocityMeasurementData {
+    double sigma_velocity_mps{1.0e-3};
+};
+
+struct TdoaPositionMeasurementData {
+    Eigen::Vector3d position{Eigen::Vector3d::Zero()};
+    double confidence{0.0};
+    bool heuristic_only{true};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+using EstimatorMeasurementData =
+    std::variant<ImuMeasurementData, VisualPoseMeasurementData, AltitudeMeasurementData,
+                 ZeroVelocityMeasurementData, TdoaPositionMeasurementData>;
+
+struct EstimatorMeasurement {
+    MeasurementHeader header{};
+    EstimatorMeasurementData data{};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct MeasurementValidationResult {
+    MeasurementValidationStatus status{MeasurementValidationStatus::ACCEPTED};
+    std::string reason{"accepted"};
+    bool consumed{false};
+    bool orientation_consumed{false};
+};
+
+} // namespace drone::estimation

--- a/include/estimation/MeasurementAdapters.hpp
+++ b/include/estimation/MeasurementAdapters.hpp
@@ -14,8 +14,8 @@ struct MeasurementAdapterResult {
 
 class MeasurementAdapters {
 public:
-    [[nodiscard]] static MeasurementAdapterResult adapt_imu(const drone::sensors::ImuMeasurement& imu,
-                                                            uint64_t sequence_id);
+    [[nodiscard]] static MeasurementAdapterResult
+    adapt_imu(const drone::sensors::ImuMeasurement& imu, uint64_t sequence_id);
     [[nodiscard]] static MeasurementAdapterResult
     adapt_visual_pose(double timestamp_s, const Eigen::Vector3d& position,
                       const Eigen::Vector3d& velocity, const Eigen::Quaterniond& orientation,
@@ -30,9 +30,9 @@ public:
     [[nodiscard]] static MeasurementAdapterResult
     adapt_tdoa_position_candidate(double timestamp_s, const Eigen::Vector3d& position,
                                   double confidence, uint64_t sequence_id);
-    [[nodiscard]] static MeasurementValidationResult validate(const EstimatorMeasurement& measurement,
-                                                              double newest_timestamp_s,
-                                                              double max_staleness_s);
+    [[nodiscard]] static MeasurementValidationResult
+    validate(const EstimatorMeasurement& measurement, double newest_timestamp_s,
+             double max_staleness_s);
 };
 
 } // namespace drone::estimation

--- a/include/estimation/MeasurementAdapters.hpp
+++ b/include/estimation/MeasurementAdapters.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "estimation/EstimatorMeasurement.hpp"
+#include "sensors/IMUSensor.hpp"
+
+#include <optional>
+
+namespace drone::estimation {
+
+struct MeasurementAdapterResult {
+    MeasurementValidationResult validation{};
+    std::optional<EstimatorMeasurement> measurement;
+};
+
+class MeasurementAdapters {
+public:
+    [[nodiscard]] static MeasurementAdapterResult adapt_imu(const drone::sensors::ImuMeasurement& imu,
+                                                            uint64_t sequence_id);
+    [[nodiscard]] static MeasurementAdapterResult
+    adapt_visual_pose(double timestamp_s, const Eigen::Vector3d& position,
+                      const Eigen::Vector3d& velocity, const Eigen::Quaterniond& orientation,
+                      double quality, bool update_accepted, uint64_t sequence_id,
+                      bool allow_orientation_fusion);
+    [[nodiscard]] static MeasurementAdapterResult adapt_manual_zupt(double timestamp_s,
+                                                                    uint64_t sequence_id);
+    [[nodiscard]] static MeasurementAdapterResult adapt_altitude(double timestamp_s,
+                                                                 double altitude_m, double sigma_m,
+                                                                 CoordinateFrame frame,
+                                                                 uint64_t sequence_id);
+    [[nodiscard]] static MeasurementAdapterResult
+    adapt_tdoa_position_candidate(double timestamp_s, const Eigen::Vector3d& position,
+                                  double confidence, uint64_t sequence_id);
+    [[nodiscard]] static MeasurementValidationResult validate(const EstimatorMeasurement& measurement,
+                                                              double newest_timestamp_s,
+                                                              double max_staleness_s);
+};
+
+} // namespace drone::estimation

--- a/include/estimation/MinimalEskfAdapter.hpp
+++ b/include/estimation/MinimalEskfAdapter.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "estimation/StateEstimator.hpp"
+
+namespace drone::estimation {
+
+class MinimalEskfAdapter final : public StateEstimator {
+public:
+    explicit MinimalEskfAdapter(drone::vio::EKFConfig config = {});
+
+    void set_validation_config(const drone::vio::EstimatorValidationConfig& config);
+
+    void reset(const EstimatorInitialState& initial) override;
+    EstimatorUpdateResult process(const EstimatorMeasurement& measurement) override;
+    [[nodiscard]] EstimatorSnapshot snapshot() const override;
+    [[nodiscard]] drone::vio::EstimatorDiagnostics diagnostics() const override;
+    [[nodiscard]] EstimatorCapabilities capabilities() const override;
+    [[nodiscard]] std::string_view name() const noexcept override;
+
+    [[nodiscard]] drone::vio::EKFEstimator& estimator() noexcept {
+        return estimator_;
+    }
+    [[nodiscard]] const drone::vio::EKFEstimator& estimator() const noexcept {
+        return estimator_;
+    }
+
+private:
+    [[nodiscard]] EstimatorUpdateResult unsupported_result(const EstimatorMeasurement& measurement,
+                                                           MeasurementValidationStatus status,
+                                                           std::string reason) const;
+
+    drone::vio::EKFEstimator estimator_;
+    drone::vio::EstimatorValidationConfig validation_{};
+    uint64_t last_sequence_id_{0};
+    double last_timestamp_s_{-1.0};
+};
+
+} // namespace drone::estimation

--- a/include/estimation/ReplayRunner.hpp
+++ b/include/estimation/ReplayRunner.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "estimation/EstimatorCoordinator.hpp"
+#include "estimation/MeasurementAdapters.hpp"
+#include "estimation/MinimalEskfAdapter.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace drone::estimation {
+
+enum class ReplayMode : uint8_t {
+    ACTIVE_ONLY = 0,
+    ACTIVE_WITH_IDENTICAL_SHADOW,
+};
+
+struct ReplayLimits {
+    size_t max_file_bytes{512 * 1024};
+    size_t max_record_count{100000};
+    size_t max_string_length{128};
+};
+
+struct ReplayRunConfig {
+    ReplayMode mode{ReplayMode::ACTIVE_ONLY};
+    ReplayLimits limits{};
+    drone::vio::EKFConfig ekf_config{};
+    drone::vio::EstimatorValidationConfig validation{};
+};
+
+struct ReplayReport {
+    int report_schema_version{1};
+    int replay_input_schema_version{0};
+    std::string replay_mode{"active_only"};
+    std::string active_estimator_name{"minimal_eskf"};
+    std::string shadow_estimator_name{"disabled"};
+    std::string coordinate_frame{"unknown"};
+    size_t input_record_count{0};
+    size_t processed_record_count{0};
+    uint64_t accepted_update_count{0};
+    uint64_t rejected_update_count{0};
+    uint64_t invalid_record_count{0};
+    uint64_t timestamp_violation_count{0};
+    uint64_t unsupported_measurement_count{0};
+    drone::vio::PoseEstimate final_pose{};
+    double final_position_uncertainty_m{0.0};
+    std::string active_estimator_health{"initializing"};
+    std::string shadow_estimator_health{"disabled"};
+    double active_shadow_position_delta_m{0.0};
+    double active_shadow_velocity_delta_mps{0.0};
+    double active_shadow_orientation_delta_deg{0.0};
+    uint64_t comparable_snapshot_count{0};
+    uint64_t skipped_comparison_count{0};
+    uint64_t shadow_dropped_event_count{0};
+    size_t shadow_queue_high_water_mark{0};
+    std::string shadow_synchronization_state{"disabled"};
+    std::string deterministic_result_hash{};
+    double average_propagation_latency_us{0.0};
+    double maximum_propagation_latency_us{0.0};
+    double average_measurement_update_latency_us{0.0};
+    double maximum_measurement_update_latency_us{0.0};
+    bool success{false};
+    std::string failure_reason{"none"};
+};
+
+struct ReplayRunResult {
+    ReplayReport report{};
+    int exit_code{1};
+};
+
+[[nodiscard]] ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
+                                              const ReplayRunConfig& config);
+[[nodiscard]] std::string replay_report_json(const ReplayReport& report);
+[[nodiscard]] std::string to_string(ReplayMode mode);
+
+} // namespace drone::estimation

--- a/include/estimation/StateEstimator.hpp
+++ b/include/estimation/StateEstimator.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "estimation/EstimatorMeasurement.hpp"
+#include "vio/EKFEstimator.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace drone::estimation {
+
+enum class EstimatorCapability : uint8_t {
+    IMU_PROPAGATION = 0,
+    VISUAL_POSITION_UPDATE,
+    VISUAL_VELOCITY_UPDATE,
+    VISUAL_ORIENTATION_UPDATE,
+    DEPTH_UPDATE,
+    ZERO_VELOCITY_UPDATE,
+    UWB_RANGE_UPDATE,
+    TDOA_UPDATE,
+    LOOP_CLOSURE_CORRECTION,
+    FEJ,
+    MSCKF,
+    COUNT,
+};
+
+struct EstimatorCapabilities {
+    std::array<bool, static_cast<size_t>(EstimatorCapability::COUNT)> supported{};
+
+    [[nodiscard]] bool has(EstimatorCapability capability) const {
+        return supported[static_cast<size_t>(capability)];
+    }
+
+    void set(EstimatorCapability capability, bool value = true) {
+        supported[static_cast<size_t>(capability)] = value;
+    }
+};
+
+enum class EstimatorUpdateStatus : uint8_t {
+    ACCEPTED = 0,
+    REJECTED,
+    IGNORED,
+};
+
+struct EstimatorInitialState {
+    Eigen::Vector3d position{Eigen::Vector3d::Zero()};
+    Eigen::Quaterniond orientation{Eigen::Quaterniond::Identity()};
+    Eigen::Vector3d velocity{Eigen::Vector3d::Zero()};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct EstimatorSnapshot {
+    drone::vio::PoseEstimate pose{};
+    drone::vio::EstimatorDiagnostics diagnostics{};
+    uint64_t last_sequence_id{0};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct EstimatorUpdateResult {
+    EstimatorUpdateStatus status{EstimatorUpdateStatus::IGNORED};
+    MeasurementValidationResult validation{};
+    EstimatorSnapshot snapshot{};
+};
+
+class StateEstimator {
+public:
+    virtual ~StateEstimator() = default;
+
+    virtual void reset(const EstimatorInitialState& initial) = 0;
+    virtual EstimatorUpdateResult process(const EstimatorMeasurement& measurement) = 0;
+    [[nodiscard]] virtual EstimatorSnapshot snapshot() const = 0;
+    [[nodiscard]] virtual drone::vio::EstimatorDiagnostics diagnostics() const = 0;
+    [[nodiscard]] virtual EstimatorCapabilities capabilities() const = 0;
+    [[nodiscard]] virtual std::string_view name() const noexcept = 0;
+};
+
+} // namespace drone::estimation

--- a/include/runtime/RuntimeMode.hpp
+++ b/include/runtime/RuntimeMode.hpp
@@ -24,6 +24,35 @@ struct RuntimeFileConfig {
     std::string anchor_config_path;
     std::string lidar_config_path;
     std::string detector_labels_path;
+    bool estimator_config_present{false};
+    bool estimator_config_valid{true};
+    std::vector<std::string> estimator_errors{};
+    std::string estimator_mode{"minimal"};
+    bool estimator_enable_experimental_hybrid{false};
+    bool estimator_enable_fej{false};
+    bool estimator_enable_msckf{false};
+    bool estimator_enable_loop_closure_correction{false};
+    bool estimator_enable_automatic_zupt{false};
+    bool estimator_shadow_requested{false};
+    bool estimator_enable_shadow_estimator{false};
+    bool estimator_shadow_effective{false};
+#ifdef DRONE_ENABLE_EXPERIMENTAL_ESTIMATOR_SHADOW
+    bool estimator_shadow_compile_time_supported{true};
+#else
+    bool estimator_shadow_compile_time_supported{false};
+#endif
+    bool estimator_shadow_comparison_enabled{true};
+    std::string estimator_shadow_implementation{"minimal_eskf_clone"};
+    size_t estimator_shadow_max_queue_depth{512};
+    double estimator_shadow_max_lag_ms{100.0};
+    double estimator_shadow_position_divergence_m{0.25};
+    double estimator_shadow_velocity_divergence_mps{0.20};
+    double estimator_shadow_orientation_divergence_deg{5.0};
+    uint32_t estimator_shadow_required_consecutive_divergent_samples{10};
+    bool estimator_reject_non_finite_measurements{true};
+    bool estimator_require_monotonic_timestamps{true};
+    double estimator_max_imu_dt_s{0.1};
+    bool estimator_diagnostics_enabled{true};
 };
 
 struct RuntimeValidationInputs {

--- a/include/vio/EKFEstimator.hpp
+++ b/include/vio/EKFEstimator.hpp
@@ -10,7 +10,9 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <array>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <numbers>
 #include <optional>
@@ -58,6 +60,67 @@ struct EKFConfig {
 
     // Outlier rejection gate (chiÂ² threshold, 3 dof)
     double mahal_gate{7.815};
+};
+
+enum class EstimatorSensorType : uint8_t {
+    IMU = 0,
+    VISION_FEATURE = 1,
+    VISUAL_POSE = 2,
+    DEPTH = 3,
+    ZUPT = 4,
+    COUNT = 5,
+};
+
+enum class EstimatorHealthState : uint8_t {
+    INITIALIZING = 0,
+    NOMINAL,
+    DEGRADED,
+    REJECTING_MEASUREMENTS,
+    NUMERICAL_WARNING,
+    INVALID,
+};
+
+struct EstimatorValidationConfig {
+    std::string mode{"minimal"};
+    bool enable_experimental_hybrid{false};
+    bool enable_fej{false};
+    bool enable_msckf{false};
+    bool enable_loop_closure_correction{false};
+    bool enable_automatic_zupt{false};
+    bool enable_shadow_estimator{false};
+    bool shadow_comparison_enabled{true};
+    size_t shadow_max_queue_depth{512};
+    double shadow_max_lag_ms{100.0};
+    double shadow_position_divergence_m{0.25};
+    double shadow_velocity_divergence_mps{0.20};
+    double shadow_orientation_divergence_deg{5.0};
+    uint32_t shadow_required_consecutive_divergent_samples{10};
+    bool reject_non_finite_measurements{true};
+    bool require_monotonic_timestamps{true};
+    double max_imu_dt_s{0.1};
+    bool diagnostics_enabled{true};
+};
+
+struct EstimatorDiagnostics {
+    uint64_t propagation_count{0};
+    std::array<uint64_t, static_cast<size_t>(EstimatorSensorType::COUNT)> accepted_updates{};
+    std::array<uint64_t, static_cast<size_t>(EstimatorSensorType::COUNT)> rejected_updates{};
+    uint64_t invalid_input_count{0};
+    uint64_t timestamp_rejection_count{0};
+    uint64_t dropped_sensor_event_count{0};
+    double last_innovation_magnitude{0.0};
+    double last_mahalanobis_distance{0.0};
+    double covariance_symmetry_error{0.0};
+    double covariance_min_diagonal{0.0};
+    double max_covariance_asymmetry{0.0};
+    double minimum_covariance_diagonal_seen{0.0};
+    double max_update_latency_us{0.0};
+    double average_propagation_latency_us{0.0};
+    double average_measurement_latency_us{0.0};
+    bool has_non_finite_state{false};
+    bool has_non_finite_covariance{false};
+    EstimatorHealthState health_state{EstimatorHealthState::INITIALIZING};
+    std::string last_rejection_reason{"none"};
 };
 
 // Pose output
@@ -125,11 +188,21 @@ public:
     //  Query â”€
     [[nodiscard]] PoseEstimate state() const;
     [[nodiscard]] double total_drift_m() const {
-        return total_drift_;
+        return estimated_position_uncertainty_m_;
+    }
+    [[nodiscard]] double estimated_position_uncertainty_m() const {
+        return estimated_position_uncertainty_m_;
     }
     [[nodiscard]] bool is_initialized() const {
         return initialized_;
     }
+    [[nodiscard]] EstimatorDiagnostics diagnostics() const;
+    void set_validation_config(EstimatorValidationConfig config);
+    [[nodiscard]] const EstimatorValidationConfig& validation_config() const {
+        return validation_cfg_;
+    }
+    void note_timestamp_violation(const std::string& reason);
+    void note_dropped_sensor_event(const std::string& reason);
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -145,6 +218,28 @@ private:
     // Box-plus / box-minus for error-state
     static Eigen::Vector3d quat_to_rotvec(const Eigen::Quaterniond& q);
     static Eigen::Quaterniond rotvec_to_quat(const Eigen::Vector3d& rv);
+    static constexpr size_t sensor_index(EstimatorSensorType sensor) {
+        return static_cast<size_t>(sensor);
+    }
+
+    template <int N>
+    bool apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
+                             const Eigen::Matrix<double, N, 1>& innovation,
+                             const Eigen::Matrix<double, N, N>& R_meas,
+                             EstimatorSensorType sensor_type, const char* sensor_name,
+                             bool apply_velocity = true, bool apply_biases = true,
+                             bool apply_attitude = true, bool enable_gating = true);
+    [[nodiscard]] bool validate_measurement_noise(double sigma_m, const char* sensor_name);
+    [[nodiscard]] bool validate_state_finite() const;
+    [[nodiscard]] bool validate_covariance_finite() const;
+    void finalize_covariance_locked();
+    void mark_measurement_rejected(EstimatorSensorType sensor_type, std::string reason);
+    void mark_measurement_accepted(EstimatorSensorType sensor_type, double innovation_magnitude,
+                                   double mahalanobis_distance);
+    void mark_invalid_input(std::string reason);
+    void update_health_locked();
+    void accumulate_propagation_latency(double latency_us);
+    void accumulate_measurement_latency(double latency_us);
 
     // Nominal state
     Eigen::Vector3d pos_{Eigen::Vector3d::Zero()};
@@ -160,12 +255,14 @@ private:
     QNoiseMat Q_imu_{QNoiseMat::Zero()};
 
     double timestamp_{0.0};
-    double total_drift_{0.0};
+    double estimated_position_uncertainty_m_{0.0};
     bool initialized_{false};
     double last_vision_update_ts_{-1.0};
     double last_depth_update_ts_{-1.0};
 
     EKFConfig cfg_;
+    EstimatorValidationConfig validation_cfg_{};
+    EstimatorDiagnostics diagnostics_{};
     mutable std::mutex mtx_;
 
     std::shared_ptr<spdlog::logger> logger_{spdlog::get("EKF")};

--- a/include/vio/VIOPipeline.hpp
+++ b/include/vio/VIOPipeline.hpp
@@ -9,6 +9,9 @@
 // Drone Swarm Sensor Fusion  |  Phase 2
 
 #include "vio/EKFEstimator.hpp"
+#include "estimation/EstimatorCoordinator.hpp"
+#include "estimation/MeasurementAdapters.hpp"
+#include "estimation/MinimalEskfAdapter.hpp"
 #include "sensors/IMUSensor.hpp"
 #include "sensors/CameraSensor.hpp"
 #include "sensors/LidarSensor.hpp"
@@ -87,6 +90,21 @@ struct RuntimeTelemetry {
     double visual_update_confidence{0.0};
     bool visual_frontend_valid{false};
     bool visual_placeholder_active{false};
+    std::string active_estimator_name{"minimal_eskf"};
+    std::string shadow_estimator_name{"disabled"};
+    std::string active_estimator_health{"initializing"};
+    std::string shadow_estimator_health{"disabled"};
+    bool shadow_enabled{false};
+    double shadow_lag_ms{0.0};
+    size_t shadow_queue_depth{0};
+    size_t shadow_queue_high_water_mark{0};
+    uint64_t shadow_dropped_events{0};
+    double shadow_position_delta_m{0.0};
+    double shadow_velocity_delta_mps{0.0};
+    double shadow_orientation_delta_deg{0.0};
+    bool shadow_divergence_active{false};
+    std::string shadow_last_failure_reason{"none"};
+    uint64_t shadow_comparable_snapshot_count{0};
 };
 
 struct VisualFrontendMetrics {
@@ -121,7 +139,7 @@ class VIOPipeline {
 public:
     using PoseCallback = std::function<void(const PoseEstimate&)>;
 
-    explicit VIOPipeline(EKFConfig cfg = EKFConfig{}) : ekf_(cfg) {}
+    explicit VIOPipeline(EKFConfig cfg = EKFConfig{});
 
     ~VIOPipeline() {
         stop();
@@ -139,11 +157,18 @@ public:
     void set_runtime_mode(drone::runtime::RuntimeMode mode) {
         runtime_mode_ = mode;
     }
+    void set_estimator_validation_config(const EstimatorValidationConfig& config) {
+        estimator_validation_config_ = config;
+        active_estimator_->set_validation_config(config);
+    }
+    [[nodiscard]] EstimatorDiagnostics estimator_diagnostics() const {
+        return coordinator_.active_snapshot().diagnostics;
+    }
 
     //  State query â”€
     [[nodiscard]] PoseEstimate current_pose() const;
     [[nodiscard]] double drift_m() const {
-        return ekf_.total_drift_m();
+        return coordinator_.active_snapshot().pose.drift_m;
     }
     [[nodiscard]] RuntimeTelemetry runtime_telemetry() const {
         std::lock_guard lock(runtime_mutex_);
@@ -167,6 +192,22 @@ public:
         telemetry.visual_update_confidence = runtime_telemetry_.visual_update_confidence;
         telemetry.visual_frontend_valid = runtime_telemetry_.visual_frontend_valid;
         telemetry.visual_placeholder_active = runtime_telemetry_.visual_placeholder_active;
+        telemetry.active_estimator_name = runtime_telemetry_.active_estimator_name;
+        telemetry.shadow_estimator_name = runtime_telemetry_.shadow_estimator_name;
+        telemetry.active_estimator_health = runtime_telemetry_.active_estimator_health;
+        telemetry.shadow_estimator_health = runtime_telemetry_.shadow_estimator_health;
+        telemetry.shadow_enabled = runtime_telemetry_.shadow_enabled;
+        telemetry.shadow_lag_ms = runtime_telemetry_.shadow_lag_ms;
+        telemetry.shadow_queue_depth = runtime_telemetry_.shadow_queue_depth;
+        telemetry.shadow_queue_high_water_mark = runtime_telemetry_.shadow_queue_high_water_mark;
+        telemetry.shadow_dropped_events = runtime_telemetry_.shadow_dropped_events;
+        telemetry.shadow_position_delta_m = runtime_telemetry_.shadow_position_delta_m;
+        telemetry.shadow_velocity_delta_mps = runtime_telemetry_.shadow_velocity_delta_mps;
+        telemetry.shadow_orientation_delta_deg = runtime_telemetry_.shadow_orientation_delta_deg;
+        telemetry.shadow_divergence_active = runtime_telemetry_.shadow_divergence_active;
+        telemetry.shadow_last_failure_reason = runtime_telemetry_.shadow_last_failure_reason;
+        telemetry.shadow_comparable_snapshot_count =
+            runtime_telemetry_.shadow_comparable_snapshot_count;
         runtime_telemetry_ = std::move(telemetry);
     }
 
@@ -180,8 +221,14 @@ private:
     void handle(const sensors::CameraFrame& frame);
     void handle(const sensors::LidarMeasurement&);
     void apply_visual_quality_to_pose(PoseEstimate& pose) const;
+    void update_shadow_runtime_telemetry();
+    [[nodiscard]] static std::string estimator_health_to_string(EstimatorHealthState state);
+    [[nodiscard]] static std::string shadow_health_to_string(estimation::ShadowHealthState state);
 
-    EKFEstimator ekf_;
+    EKFConfig ekf_config_{};
+    std::shared_ptr<estimation::MinimalEskfAdapter> active_estimator_;
+    estimation::EstimatorCoordinator coordinator_;
+    EstimatorValidationConfig estimator_validation_config_{};
 
     std::shared_ptr<sensors::IMUSensor> imu_;
     std::shared_ptr<sensors::CameraSensor> cam_;
@@ -206,6 +253,7 @@ private:
     VisualFrontendMetrics last_visual_metrics_{};
     mutable std::mutex runtime_mutex_;
     RuntimeTelemetry runtime_telemetry_{};
+    uint64_t measurement_sequence_{0};
 
     std::shared_ptr<spdlog::logger> logger_{spdlog::get("VIO")};
 };

--- a/scripts/phase15_estimator_replay.py
+++ b/scripts/phase15_estimator_replay.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Phase 15 deterministic estimator replay baseline."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import pathlib
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+
+
+MAX_RECORDS = 100_000
+MAX_FILE_BYTES = 8 * 1024 * 1024
+SUPPORTED_VERSION = 1
+
+
+@dataclass
+class ReplayStats:
+    accepted_measurements: int = 0
+    rejected_measurements: int = 0
+    invalid_inputs: int = 0
+    timestamp_violations: int = 0
+    propagation_latency_us: list[float] | None = None
+    measurement_latency_us: list[float] | None = None
+    max_update_latency_us: float = 0.0
+
+    def __post_init__(self) -> None:
+        self.propagation_latency_us = []
+        self.measurement_latency_us = []
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def finite_vector(values: list[float], expected_len: int, name: str) -> list[float]:
+    if not isinstance(values, list) or len(values) != expected_len:
+        raise ValueError(f"{name} must contain exactly {expected_len} finite values")
+    parsed = [float(v) for v in values]
+    if not all(math.isfinite(v) for v in parsed):
+        raise ValueError(f"{name} must be finite")
+    return parsed
+
+
+def load_replay(path: pathlib.Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(f"replay file not found: {path}")
+    if path.stat().st_size > MAX_FILE_BYTES:
+        raise ValueError(f"replay file exceeds {MAX_FILE_BYTES} byte limit")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("version") != SUPPORTED_VERSION:
+        raise ValueError(f"unsupported replay version: {payload.get('version')}")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("records must be a list")
+    if len(records) > MAX_RECORDS:
+        raise ValueError(f"record count exceeds {MAX_RECORDS}")
+    return payload
+
+
+def run_replay(payload: dict) -> dict:
+    gravity = [0.0, 0.0, -9.81]
+    position = finite_vector(
+        payload.get("initial_state", {}).get("position", [0.0, 0.0, 0.0]),
+        3,
+        "initial position",
+    )
+    velocity = finite_vector(
+        payload.get("initial_state", {}).get("velocity", [0.0, 0.0, 0.0]),
+        3,
+        "initial velocity",
+    )
+    yaw = float(payload.get("initial_state", {}).get("yaw_rad", 0.0))
+    if not math.isfinite(yaw):
+        raise ValueError("initial yaw_rad must be finite")
+
+    stats = ReplayStats()
+    timestamps: list[float] = []
+    ground_truth = None
+    for record in payload["records"]:
+        if not isinstance(record, dict):
+            raise ValueError("every record must be an object")
+        kind = record.get("type")
+        stamp = float(record.get("timestamp_s"))
+        if not math.isfinite(stamp):
+            raise ValueError("timestamp_s must be finite")
+        if timestamps and stamp <= timestamps[-1]:
+            stats.timestamp_violations += 1
+            raise ValueError("timestamps must be strictly monotonic")
+        timestamps.append(stamp)
+
+        started = time.perf_counter()
+        if kind == "imu":
+            accel = finite_vector(record.get("accel_mps2", []), 3, "accel_mps2")
+            gyro = finite_vector(record.get("gyro_rads", []), 3, "gyro_rads")
+            dt = 0.0 if len(timestamps) == 1 else stamp - timestamps[-2]
+            if dt < 0.0 or dt > 0.1:
+                stats.timestamp_violations += 1
+                raise ValueError(f"imu dt out of range: {dt}")
+            yaw += gyro[2] * dt
+            world_accel = [accel[0], accel[1], accel[2] + gravity[2]]
+            position = [
+                position[i] + velocity[i] * dt + 0.5 * world_accel[i] * dt * dt
+                for i in range(3)
+            ]
+            velocity = [velocity[i] + world_accel[i] * dt for i in range(3)]
+            stats.propagation_latency_us.append((time.perf_counter() - started) * 1e6)
+        elif kind == "depth":
+            depth_z = float(record.get("z_world_m"))
+            sigma = float(record.get("sigma_m", 0.05))
+            if not math.isfinite(depth_z) or not math.isfinite(sigma) or sigma <= 0.0:
+                stats.invalid_inputs += 1
+                continue
+            innovation = depth_z - position[2]
+            if abs(innovation) > max(1.0, 8.0 * sigma):
+                stats.rejected_measurements += 1
+            else:
+                position[2] += innovation * 0.8
+                stats.accepted_measurements += 1
+            stats.measurement_latency_us.append((time.perf_counter() - started) * 1e6)
+        elif kind == "visual_pose":
+            measured_position = finite_vector(
+                record.get("position_m", []), 3, "position_m"
+            )
+            measured_velocity = finite_vector(
+                record.get("velocity_mps", []), 3, "velocity_mps"
+            )
+            sigma_position = float(record.get("sigma_position_m", 0.35))
+            sigma_velocity = float(record.get("sigma_velocity_mps", 0.45))
+            if min(sigma_position, sigma_velocity) <= 0.0:
+                stats.invalid_inputs += 1
+                continue
+            residual = math.sqrt(
+                sum((measured_position[i] - position[i]) ** 2 for i in range(3))
+            )
+            if residual > max(2.0, 8.0 * sigma_position):
+                stats.rejected_measurements += 1
+            else:
+                position = [
+                    0.6 * position[i] + 0.4 * measured_position[i] for i in range(3)
+                ]
+                velocity = [
+                    0.6 * velocity[i] + 0.4 * measured_velocity[i] for i in range(3)
+                ]
+                stats.accepted_measurements += 1
+            stats.measurement_latency_us.append((time.perf_counter() - started) * 1e6)
+        elif kind == "ground_truth":
+            ground_truth = {
+                "position": finite_vector(
+                    record.get("position_m", []), 3, "ground truth position_m"
+                ),
+                "velocity": finite_vector(
+                    record.get("velocity_mps", []), 3, "ground truth velocity_mps"
+                ),
+                "yaw_rad": float(record.get("yaw_rad", 0.0)),
+            }
+            if not math.isfinite(ground_truth["yaw_rad"]):
+                raise ValueError("ground truth yaw_rad must be finite")
+        else:
+            raise ValueError(f"unsupported record type: {kind}")
+
+    all_latencies = stats.propagation_latency_us + stats.measurement_latency_us
+    stats.max_update_latency_us = max(all_latencies, default=0.0)
+    replay_hash = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    final_position_error = None
+    final_velocity_error = None
+    orientation_error_deg = None
+    if ground_truth is not None:
+        final_position_error = math.sqrt(
+            sum((position[i] - ground_truth["position"][i]) ** 2 for i in range(3))
+        )
+        final_velocity_error = math.sqrt(
+            sum((velocity[i] - ground_truth["velocity"][i]) ** 2 for i in range(3))
+        )
+        orientation_error_deg = abs(yaw - ground_truth["yaw_rad"]) * (180.0 / math.pi)
+
+    return {
+        "version": SUPPORTED_VERSION,
+        "records_processed": len(payload["records"]),
+        "final_state": {
+            "position_m": position,
+            "velocity_mps": velocity,
+            "yaw_rad": yaw,
+        },
+        "metrics": {
+            "final_position_error_m": final_position_error,
+            "final_velocity_error_mps": final_velocity_error,
+            "orientation_error_deg": orientation_error_deg,
+            "estimated_position_uncertainty_m": None,
+            "maximum_covariance_asymmetry": 0.0,
+            "minimum_covariance_diagonal": 0.0,
+            "accepted_measurements": stats.accepted_measurements,
+            "rejected_measurements": stats.rejected_measurements,
+            "invalid_inputs": stats.invalid_inputs,
+            "timestamp_violations": stats.timestamp_violations,
+            "maximum_update_latency_us": stats.max_update_latency_us,
+            "average_propagation_latency_us": (
+                statistics.fmean(stats.propagation_latency_us)
+                if stats.propagation_latency_us
+                else 0.0
+            ),
+            "average_measurement_latency_us": (
+                statistics.fmean(stats.measurement_latency_us)
+                if stats.measurement_latency_us
+                else 0.0
+            ),
+            "nan_or_infinity_occurrence": False,
+            "deterministic_replay_hash": replay_hash,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to replay JSON")
+    parser.add_argument(
+        "--output", required=True, help="Path to machine-readable JSON report"
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = load_replay(pathlib.Path(args.input))
+        result = run_replay(payload)
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+
+    output_path = pathlib.Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase16_benchmark_aggregate.py
+++ b/scripts/phase16_benchmark_aggregate.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import random
+import shutil
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCENARIOS = {
+    "active_only": {"repetitions": 10},
+    "active_with_shadow": {"repetitions": 10},
+    "shadow_overload": {"repetitions": 5},
+}
+
+
+@dataclass(frozen=True)
+class RunRequest:
+    scenario: str
+    repetition_index: int
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def detect_cpu_model() -> str:
+    if sys.platform.startswith("linux"):
+        cpuinfo = Path("/proc/cpuinfo")
+        if cpuinfo.exists():
+            for line in cpuinfo.read_text(encoding="utf-8", errors="replace").splitlines():
+                if line.lower().startswith("model name"):
+                    return line.split(":", 1)[1].strip()
+    return platform.processor() or "unknown"
+
+
+def compute_stats(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "mean": 0.0,
+            "median": 0.0,
+            "p95": 0.0,
+            "p99": 0.0,
+            "min": 0.0,
+            "max": 0.0,
+            "stddev": 0.0,
+            "sample_count": 0,
+        }
+
+    ordered = sorted(values)
+    mean = statistics.fmean(ordered)
+    median = statistics.median(ordered)
+
+    def percentile(p: float) -> float:
+        if len(ordered) == 1:
+            return ordered[0]
+        index = round(p * (len(ordered) - 1))
+        return ordered[index]
+
+    stddev = statistics.pstdev(ordered) if len(ordered) > 1 else 0.0
+    return {
+        "mean": mean,
+        "median": median,
+        "p95": percentile(0.95),
+        "p99": percentile(0.99),
+        "min": ordered[0],
+        "max": ordered[-1],
+        "stddev": stddev,
+        "sample_count": len(ordered),
+    }
+
+
+def confidence_interval_95(values: list[float]) -> dict[str, float] | None:
+    if len(values) < 2:
+        return None
+    mean = statistics.fmean(values)
+    stddev = statistics.stdev(values)
+    margin = 1.96 * stddev / math.sqrt(len(values))
+    return {"low": mean - margin, "high": mean + margin}
+
+
+def extract_single_scenario(report: dict[str, Any]) -> dict[str, Any]:
+    scenarios = report.get("scenarios", [])
+    if len(scenarios) != 1:
+        raise ValueError("benchmark run did not return exactly one scenario")
+    return scenarios[0]
+
+
+def summarize_scenario_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    active_run_means = [run["active_process_latency_us"]["mean"] for run in runs]
+    active_all_samples = [
+        sample
+        for run in runs
+        for sample in run.get("active_process_samples_us", [])
+    ]
+    shadow_all_samples = [
+        sample
+        for run in runs
+        for sample in run.get("shadow_processing_samples_us", [])
+    ]
+    active_medians = [run["active_process_latency_us"]["median"] for run in runs]
+    shadow_medians = [
+        run["shadow_processing_latency_us"]["median"]
+        for run in runs
+        if run["shadow_processing_latency_us"]["sample_count"] > 0
+    ]
+    active_output_failures = sum(
+        1 for run in runs if not run["active_output_matches_baseline"]
+    )
+    failed_runs = sum(1 for run in runs if not run["success"])
+    active_stats = compute_stats(active_all_samples)
+    shadow_stats = compute_stats(shadow_all_samples)
+    run_mean_stats = compute_stats(active_run_means)
+    median_difference = (
+        statistics.fmean(active_medians) - statistics.fmean(shadow_medians)
+        if shadow_medians
+        else 0.0
+    )
+    percentage_difference = (
+        (statistics.fmean(shadow_medians) - statistics.fmean(active_medians))
+        / statistics.fmean(active_medians)
+        * 100.0
+        if shadow_medians and statistics.fmean(active_medians) > 0.0
+        else 0.0
+    )
+
+    return {
+        "run_count": len(runs),
+        "failed_run_count": failed_runs,
+        "output_equivalence_failure_count": active_output_failures,
+        "active_run_mean_us": {
+            "mean_of_run_means": statistics.fmean(active_run_means) if active_run_means else 0.0,
+            "median_of_run_means": statistics.median(active_run_means) if active_run_means else 0.0,
+            "minimum_run_mean": min(active_run_means) if active_run_means else 0.0,
+            "maximum_run_mean": max(active_run_means) if active_run_means else 0.0,
+            "stddev_of_run_means": statistics.pstdev(active_run_means)
+            if len(active_run_means) > 1
+            else 0.0,
+            "confidence_interval_95": confidence_interval_95(active_run_means),
+        },
+        "active_aggregate_latency_us": active_stats,
+        "shadow_aggregate_latency_us": shadow_stats,
+        "worst_maximum_latency_us": max(
+            (run["active_process_latency_us"]["max"] for run in runs), default=0.0
+        ),
+        "average_queue_high_water_mark": statistics.fmean(
+            [run["shadow_queue_high_water_mark"] for run in runs]
+        )
+        if runs
+        else 0.0,
+        "maximum_queue_high_water_mark": max(
+            (run["shadow_queue_high_water_mark"] for run in runs), default=0
+        ),
+        "total_dropped_event_count": sum(
+            run["shadow_dropped_event_count"] for run in runs
+        ),
+        "maximum_final_lag_ms": max((run["shadow_lag_ms"] for run in runs), default=0.0),
+        "final_shadow_healths": sorted({run["shadow_health"] for run in runs}),
+        "active_versus_shadow_median_difference_us": median_difference,
+        "active_versus_shadow_percentage_difference": percentage_difference,
+        "active_run_mean_distribution_us": run_mean_stats,
+    }
+
+
+def build_run_order(seed: int) -> list[RunRequest]:
+    order = [
+        RunRequest(scenario=scenario, repetition_index=index + 1)
+        for scenario, metadata in SCENARIOS.items()
+        for index in range(metadata["repetitions"])
+    ]
+    rng = random.Random(seed)
+    rng.shuffle(order)
+    return order
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Aggregate repeated Phase 16 benchmark runs.")
+    parser.add_argument("--benchmark-exe", required=True, help="Path to estimator_shadow_benchmark executable")
+    parser.add_argument("--repo-root", default=".", help="Repository root")
+    parser.add_argument("--output-dir", default="artifacts", help="Artifacts output directory")
+    parser.add_argument("--warmup-iterations", type=int, default=250)
+    parser.add_argument("--measured-iterations", type=int, default=2000)
+    parser.add_argument("--seed", type=int, default=16016)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    benchmark_exe = Path(args.benchmark_exe)
+    if not benchmark_exe.is_absolute():
+        benchmark_exe = (repo_root / benchmark_exe).resolve()
+    if not benchmark_exe.exists():
+        raise FileNotFoundError(f"benchmark executable not found: {benchmark_exe}")
+
+    artifacts_root = (repo_root / args.output_dir).resolve()
+    runs_dir = artifacts_root / "phase16d_benchmark_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    aggregate_path = artifacts_root / "phase16d_benchmark_aggregate.json"
+    summary_path = artifacts_root / "phase16d_benchmark_summary.md"
+
+    git_sha = run_command(["git", "rev-parse", "HEAD"], repo_root)
+    commit_sha = git_sha.stdout.strip() if git_sha.returncode == 0 else "unknown"
+
+    run_order = build_run_order(args.seed)
+    run_records: list[dict[str, Any]] = []
+    scenario_runs: dict[str, list[dict[str, Any]]] = {scenario: [] for scenario in SCENARIOS}
+    compiler = "unknown"
+    build_type = "unknown"
+    operating_system = platform.system().lower()
+
+    for run_index, request in enumerate(run_order, start=1):
+        output_path = runs_dir / f"{run_index:02d}_{request.scenario}_run_{request.repetition_index:02d}.json"
+        command = [
+            str(benchmark_exe),
+            "--scenario",
+            request.scenario,
+            "--warmup-iterations",
+            str(args.warmup_iterations),
+            "--iterations",
+            str(args.measured_iterations),
+            "--emit-samples",
+            "--output",
+            str(output_path),
+        ]
+        completed = run_command(command, repo_root)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"benchmark run failed for {request.scenario} repetition {request.repetition_index}:\n"
+                f"stdout:\n{completed.stdout}\n\nstderr:\n{completed.stderr}"
+            )
+
+        report = json.loads(output_path.read_text(encoding="utf-8"))
+        scenario_report = extract_single_scenario(report)
+        scenario_report["command"] = command
+        scenario_report["run_index"] = run_index
+        scenario_report["repetition_index"] = request.repetition_index
+        scenario_report["raw_report_path"] = str(output_path.relative_to(repo_root))
+        run_records.append(scenario_report)
+        scenario_runs[request.scenario].append(scenario_report)
+        compiler = report.get("compiler", compiler)
+        build_type = report.get("build_type", build_type)
+        operating_system = report.get("operating_system", operating_system)
+
+    aggregates = {
+        scenario: summarize_scenario_runs(runs)
+        for scenario, runs in scenario_runs.items()
+    }
+
+    output_equivalence_ok = all(
+        run["active_output_matches_baseline"] for run in run_records
+    )
+    overload_runs = scenario_runs["shadow_overload"]
+    overload_bounded = all(
+        run["success"]
+        and run["shadow_queue_high_water_mark"] <= run["config"]["queue_depth"]
+        and run["shadow_dropped_event_count"] >= 0
+        for run in overload_runs
+    )
+
+    aggregate_report = {
+        "schema_version": 1,
+        "commit_sha": commit_sha,
+        "compiler": compiler,
+        "compiler_version": compiler,
+        "build_type": build_type,
+        "operating_system": operating_system,
+        "cpu": detect_cpu_model(),
+        "timer_source": "std::chrono::steady_clock",
+        "benchmark_configuration": {
+            "warmup_iteration_count": args.warmup_iterations,
+            "measured_iteration_count": args.measured_iterations,
+            "scenario_repetitions": {
+                scenario: metadata["repetitions"] for scenario, metadata in SCENARIOS.items()
+            },
+        },
+        "run_order_strategy": "deterministic_randomized",
+        "randomization_seed": args.seed,
+        "run_order": [
+            {
+                "run_index": index + 1,
+                "scenario": request.scenario,
+                "repetition_index": request.repetition_index,
+            }
+            for index, request in enumerate(run_order)
+        ],
+        "individual_runs": run_records,
+        "scenario_aggregates": aggregates,
+        "active_output_equivalence_result": output_equivalence_ok,
+        "shadow_overload_bounded_result": overload_bounded,
+        "pass_status": output_equivalence_ok and overload_bounded,
+        "failure_reason": "none" if output_equivalence_ok and overload_bounded else "benchmark acceptance criteria not met",
+        "limitations": [
+            "software benchmark only",
+            "does not imply hard real-time guarantees",
+            "does not imply flight readiness",
+            "timing remains sensitive to scheduler, cache, CPU frequency, and background load variance",
+        ],
+    }
+    aggregate_path.write_text(json.dumps(aggregate_report, indent=2) + "\n", encoding="utf-8")
+
+    summary_lines = [
+        "# Phase 16D Benchmark Summary",
+        "",
+        f"- Commit SHA: `{commit_sha}`",
+        f"- Compiler: `{compiler}`",
+        f"- Build type: `{build_type}`",
+        f"- Operating system: `{operating_system}`",
+        f"- CPU: `{aggregate_report['cpu']}`",
+        f"- Warm-up iterations per run: `{args.warmup_iterations}`",
+        f"- Measured iterations per run: `{args.measured_iterations}`",
+        f"- Run ordering: deterministic randomized with seed `{args.seed}`",
+        "",
+        "## Scenario aggregates",
+        "",
+    ]
+    for scenario, aggregate in aggregates.items():
+        summary_lines.extend(
+            [
+                f"### {scenario}",
+                "",
+                f"- Run count: `{aggregate['run_count']}`",
+                f"- Failed runs: `{aggregate['failed_run_count']}`",
+                f"- Output-equivalence failures: `{aggregate['output_equivalence_failure_count']}`",
+                f"- Mean of run means (active us): `{aggregate['active_run_mean_us']['mean_of_run_means']:.3f}`",
+                f"- Median of run means (active us): `{aggregate['active_run_mean_us']['median_of_run_means']:.3f}`",
+                f"- Aggregate median (active us): `{aggregate['active_aggregate_latency_us']['median']:.3f}`",
+                f"- Aggregate p95 (active us): `{aggregate['active_aggregate_latency_us']['p95']:.3f}`",
+                f"- Aggregate p99 (active us): `{aggregate['active_aggregate_latency_us']['p99']:.3f}`",
+                f"- Worst maximum latency (active us): `{aggregate['worst_maximum_latency_us']:.3f}`",
+                f"- Total dropped events: `{aggregate['total_dropped_event_count']}`",
+                f"- Maximum queue high-water mark: `{aggregate['maximum_queue_high_water_mark']}`",
+                f"- Final shadow healths: `{', '.join(aggregate['final_shadow_healths'])}`",
+                "",
+            ]
+        )
+
+    summary_lines.extend(
+        [
+            "## Acceptance summary",
+            "",
+            f"- Active-output equivalence held for all runs: `{output_equivalence_ok}`",
+            f"- Overload queue remained bounded: `{overload_bounded}`",
+            f"- Aggregate pass status: `{aggregate_report['pass_status']}`",
+            "",
+        ]
+    )
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/estimation/EstimatorComparison.cpp
+++ b/src/estimation/EstimatorComparison.cpp
@@ -1,0 +1,66 @@
+#include "estimation/EstimatorComparison.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace drone::estimation {
+
+EstimatorComparison::EstimatorComparison(ComparisonThresholds thresholds)
+    : thresholds_(thresholds) {}
+
+EstimatorComparisonSnapshot EstimatorComparison::compare(const EstimatorSnapshot& active,
+                                                         const EstimatorSnapshot& shadow,
+                                                         ShadowHealthState shadow_health) {
+    latest_.shadow_health = shadow_health;
+    latest_.active_health = active.diagnostics.health_state;
+    latest_.timestamp_delta_s = std::abs(active.pose.timestamp - shadow.pose.timestamp);
+    if (shadow_health == ShadowHealthState::FAILED || shadow_health == ShadowHealthState::STALE ||
+        shadow_health == ShadowHealthState::DISABLED) {
+        latest_.comparable = false;
+        ++latest_.skipped_comparison_count;
+        return latest_;
+    }
+    if (latest_.timestamp_delta_s > thresholds_.max_timestamp_delta_s ||
+        active.last_sequence_id != shadow.last_sequence_id) {
+        latest_.comparable = false;
+        latest_.last_divergence_reason = "history_mismatch";
+        ++latest_.skipped_comparison_count;
+        return latest_;
+    }
+
+    latest_.comparable = true;
+    latest_.position_delta_m = (active.pose.position - shadow.pose.position).norm();
+    latest_.velocity_delta_mps = (active.pose.velocity - shadow.pose.velocity).norm();
+    latest_.orientation_delta_deg =
+        Eigen::AngleAxisd(active.pose.orientation.conjugate() * shadow.pose.orientation)
+            .angle() *
+        (180.0 / std::numbers::pi_v<double>);
+    latest_.accel_bias_delta = (active.pose.accel_bias - shadow.pose.accel_bias).norm();
+    latest_.gyro_bias_delta = (active.pose.gyro_bias - shadow.pose.gyro_bias).norm();
+    latest_.uncertainty_delta =
+        std::abs(active.pose.pos_std.norm() - shadow.pose.pos_std.norm());
+    ++latest_.comparable_snapshot_count;
+
+    const bool divergent =
+        latest_.position_delta_m > thresholds_.position_divergence_m ||
+        latest_.velocity_delta_mps > thresholds_.velocity_divergence_mps ||
+        latest_.orientation_delta_deg > thresholds_.orientation_divergence_deg;
+    if (divergent) {
+        latest_.consecutive_divergent_samples += 1;
+        if (latest_.position_delta_m > thresholds_.position_divergence_m) {
+            latest_.last_divergence_reason = "position_delta";
+        } else if (latest_.velocity_delta_mps > thresholds_.velocity_divergence_mps) {
+            latest_.last_divergence_reason = "velocity_delta";
+        } else {
+            latest_.last_divergence_reason = "orientation_delta";
+        }
+    } else {
+        latest_.consecutive_divergent_samples = 0;
+        latest_.last_divergence_reason = "none";
+    }
+    latest_.diverged =
+        latest_.consecutive_divergent_samples >= thresholds_.required_consecutive_divergent_samples;
+    return latest_;
+}
+
+} // namespace drone::estimation

--- a/src/estimation/EstimatorComparison.cpp
+++ b/src/estimation/EstimatorComparison.cpp
@@ -32,19 +32,16 @@ EstimatorComparisonSnapshot EstimatorComparison::compare(const EstimatorSnapshot
     latest_.position_delta_m = (active.pose.position - shadow.pose.position).norm();
     latest_.velocity_delta_mps = (active.pose.velocity - shadow.pose.velocity).norm();
     latest_.orientation_delta_deg =
-        Eigen::AngleAxisd(active.pose.orientation.conjugate() * shadow.pose.orientation)
-            .angle() *
+        Eigen::AngleAxisd(active.pose.orientation.conjugate() * shadow.pose.orientation).angle() *
         (180.0 / std::numbers::pi_v<double>);
     latest_.accel_bias_delta = (active.pose.accel_bias - shadow.pose.accel_bias).norm();
     latest_.gyro_bias_delta = (active.pose.gyro_bias - shadow.pose.gyro_bias).norm();
-    latest_.uncertainty_delta =
-        std::abs(active.pose.pos_std.norm() - shadow.pose.pos_std.norm());
+    latest_.uncertainty_delta = std::abs(active.pose.pos_std.norm() - shadow.pose.pos_std.norm());
     ++latest_.comparable_snapshot_count;
 
-    const bool divergent =
-        latest_.position_delta_m > thresholds_.position_divergence_m ||
-        latest_.velocity_delta_mps > thresholds_.velocity_divergence_mps ||
-        latest_.orientation_delta_deg > thresholds_.orientation_divergence_deg;
+    const bool divergent = latest_.position_delta_m > thresholds_.position_divergence_m ||
+                           latest_.velocity_delta_mps > thresholds_.velocity_divergence_mps ||
+                           latest_.orientation_delta_deg > thresholds_.orientation_divergence_deg;
     if (divergent) {
         latest_.consecutive_divergent_samples += 1;
         if (latest_.position_delta_m > thresholds_.position_divergence_m) {

--- a/src/estimation/EstimatorCoordinator.cpp
+++ b/src/estimation/EstimatorCoordinator.cpp
@@ -77,14 +77,14 @@ void EstimatorCoordinator::stop_shadow() {
     shadow_estimator_.reset();
     telemetry_.queue_depth = 0;
     telemetry_.lag_ms = 0.0;
-    telemetry_.shadow_health = telemetry_.enabled ? ShadowHealthState::STOPPED : ShadowHealthState::DISABLED;
+    telemetry_.shadow_health =
+        telemetry_.enabled ? ShadowHealthState::STOPPED : ShadowHealthState::DISABLED;
 }
 
 bool EstimatorCoordinator::wait_for_shadow_idle(std::chrono::milliseconds timeout) {
     std::unique_lock lock(shadow_mutex_);
-    return shadow_idle_cv_.wait_for(lock, timeout, [this] {
-        return shadow_queue_.empty() && shadow_inflight_ == 0;
-    });
+    return shadow_idle_cv_.wait_for(
+        lock, timeout, [this] { return shadow_queue_.empty() && shadow_inflight_ == 0; });
 }
 
 EstimatorUpdateResult EstimatorCoordinator::process(const EstimatorMeasurement& measurement) {
@@ -137,7 +137,8 @@ void EstimatorCoordinator::worker_loop() {
         std::optional<QueuedMeasurement> queued;
         {
             std::unique_lock lock(shadow_mutex_);
-            shadow_cv_.wait(lock, [this] { return stop_requested_.load() || !shadow_queue_.empty(); });
+            shadow_cv_.wait(lock,
+                            [this] { return stop_requested_.load() || !shadow_queue_.empty(); });
             if (stop_requested_.load()) {
                 return;
             }
@@ -156,8 +157,9 @@ void EstimatorCoordinator::worker_loop() {
             last_shadow_snapshot_ = shadow_result.snapshot;
             telemetry_.queue_depth = shadow_queue_.size();
             telemetry_.lag_ms = lag_ms;
-            telemetry_.shadow_health = lag_ms > shadow_config_.max_lag_ms ? ShadowHealthState::LAGGING
-                                                                          : ShadowHealthState::SYNCHRONIZED;
+            telemetry_.shadow_health = lag_ms > shadow_config_.max_lag_ms
+                                           ? ShadowHealthState::LAGGING
+                                           : ShadowHealthState::SYNCHRONIZED;
             if (telemetry_.dropped_events > 0 && telemetry_.queue_depth == 0) {
                 telemetry_.shadow_health = ShadowHealthState::STALE;
             }

--- a/src/estimation/EstimatorCoordinator.cpp
+++ b/src/estimation/EstimatorCoordinator.cpp
@@ -1,0 +1,207 @@
+#include "estimation/EstimatorCoordinator.hpp"
+
+#include <chrono>
+#include <utility>
+
+namespace drone::estimation {
+
+EstimatorCoordinator::EstimatorCoordinator(std::shared_ptr<StateEstimator> active_estimator)
+    : active_estimator_(std::move(active_estimator)) {
+    telemetry_.active_estimator_name = std::string(active_estimator_->name());
+}
+
+EstimatorCoordinator::~EstimatorCoordinator() {
+    stop_shadow();
+}
+
+void EstimatorCoordinator::reset(const EstimatorInitialState& initial) {
+    std::lock_guard lock(mutex_);
+    last_initial_state_ = initial;
+    has_initial_state_ = true;
+    active_estimator_->reset(initial);
+    if (shadow_estimator_) {
+        shadow_estimator_->reset(initial);
+    }
+}
+
+void EstimatorCoordinator::configure_shadow(ShadowEstimatorConfig config,
+                                            std::unique_ptr<StateEstimator> shadow_estimator) {
+    stop_shadow();
+    std::scoped_lock lock(mutex_, shadow_mutex_);
+    shadow_config_ = std::move(config);
+    comparison_ = EstimatorComparison(shadow_config_.thresholds);
+    telemetry_.enabled = shadow_config_.enabled;
+    telemetry_.dropped_events = 0;
+    telemetry_.queue_depth = 0;
+    telemetry_.queue_high_water_mark = 0;
+    telemetry_.lag_ms = 0.0;
+    telemetry_.last_failure_reason = "none";
+    telemetry_.last_divergence_reason = "none";
+    telemetry_.divergence_active = false;
+    telemetry_.comparable = false;
+    telemetry_.comparable_snapshot_count = 0;
+    telemetry_.skipped_comparison_count = 0;
+    shadow_inflight_ = 0;
+    last_shadow_snapshot_.reset();
+    while (!shadow_queue_.empty()) {
+        shadow_queue_.pop();
+    }
+    if (!shadow_config_.enabled) {
+        telemetry_.shadow_health = ShadowHealthState::DISABLED;
+        telemetry_.shadow_estimator_name = "disabled";
+        return;
+    }
+    shadow_estimator_ = std::move(shadow_estimator);
+    telemetry_.shadow_estimator_name = std::string(shadow_estimator_->name());
+    if (has_initial_state_) {
+        shadow_estimator_->reset(last_initial_state_);
+    }
+    telemetry_.shadow_health = ShadowHealthState::STARTING;
+    stop_requested_.store(false);
+    shadow_thread_ = std::thread([this] { worker_loop(); });
+}
+
+void EstimatorCoordinator::stop_shadow() {
+    stop_requested_.store(true);
+    shadow_cv_.notify_all();
+    shadow_idle_cv_.notify_all();
+    if (shadow_thread_.joinable()) {
+        shadow_thread_.join();
+    }
+    std::scoped_lock lock(mutex_, shadow_mutex_);
+    while (!shadow_queue_.empty()) {
+        shadow_queue_.pop();
+    }
+    shadow_inflight_ = 0;
+    last_shadow_snapshot_.reset();
+    shadow_estimator_.reset();
+    telemetry_.queue_depth = 0;
+    telemetry_.lag_ms = 0.0;
+    telemetry_.shadow_health = telemetry_.enabled ? ShadowHealthState::STOPPED : ShadowHealthState::DISABLED;
+}
+
+bool EstimatorCoordinator::wait_for_shadow_idle(std::chrono::milliseconds timeout) {
+    std::unique_lock lock(shadow_mutex_);
+    return shadow_idle_cv_.wait_for(lock, timeout, [this] {
+        return shadow_queue_.empty() && shadow_inflight_ == 0;
+    });
+}
+
+EstimatorUpdateResult EstimatorCoordinator::process(const EstimatorMeasurement& measurement) {
+    EstimatorUpdateResult result;
+    {
+        std::lock_guard lock(mutex_);
+        result = active_estimator_->process(measurement);
+        telemetry_.active_health = result.snapshot.diagnostics.health_state;
+        telemetry_.active_estimator_name = std::string(active_estimator_->name());
+
+        if (!shadow_config_.enabled || !shadow_estimator_) {
+            telemetry_.enabled = false;
+            telemetry_.shadow_health = ShadowHealthState::DISABLED;
+            return result;
+        }
+    }
+
+    std::scoped_lock lock(mutex_, shadow_mutex_);
+    if (shadow_queue_.size() >= shadow_config_.max_queue_depth) {
+        shadow_queue_.pop();
+        ++telemetry_.dropped_events;
+        telemetry_.last_failure_reason = "shadow queue overflow dropped oldest event";
+        telemetry_.shadow_health = ShadowHealthState::LAGGING;
+    }
+    shadow_queue_.push({measurement, std::chrono::steady_clock::now()});
+    telemetry_.queue_depth = shadow_queue_.size();
+    telemetry_.queue_high_water_mark =
+        std::max(telemetry_.queue_high_water_mark, telemetry_.queue_depth);
+    shadow_cv_.notify_one();
+    return result;
+}
+
+EstimatorSnapshot EstimatorCoordinator::active_snapshot() const {
+    std::lock_guard lock(mutex_);
+    return active_estimator_->snapshot();
+}
+
+ShadowEstimatorTelemetry EstimatorCoordinator::telemetry() const {
+    std::lock_guard lock(mutex_);
+    return telemetry_;
+}
+
+std::optional<EstimatorSnapshot> EstimatorCoordinator::shadow_snapshot() const {
+    std::lock_guard lock(mutex_);
+    return last_shadow_snapshot_;
+}
+
+void EstimatorCoordinator::worker_loop() {
+    while (!stop_requested_.load()) {
+        std::optional<QueuedMeasurement> queued;
+        {
+            std::unique_lock lock(shadow_mutex_);
+            shadow_cv_.wait(lock, [this] { return stop_requested_.load() || !shadow_queue_.empty(); });
+            if (stop_requested_.load()) {
+                return;
+            }
+            queued = shadow_queue_.front();
+            shadow_queue_.pop();
+            shadow_inflight_ += 1;
+        }
+
+        try {
+            auto shadow_result = shadow_estimator_->process(queued->measurement);
+            const double lag_ms = std::chrono::duration<double, std::milli>(
+                                      std::chrono::steady_clock::now() - queued->enqueued_at)
+                                      .count();
+            std::scoped_lock lock(mutex_, shadow_mutex_);
+            shadow_inflight_ -= 1;
+            last_shadow_snapshot_ = shadow_result.snapshot;
+            telemetry_.queue_depth = shadow_queue_.size();
+            telemetry_.lag_ms = lag_ms;
+            telemetry_.shadow_health = lag_ms > shadow_config_.max_lag_ms ? ShadowHealthState::LAGGING
+                                                                          : ShadowHealthState::SYNCHRONIZED;
+            if (telemetry_.dropped_events > 0 && telemetry_.queue_depth == 0) {
+                telemetry_.shadow_health = ShadowHealthState::STALE;
+            }
+
+            if (shadow_config_.comparison_enabled) {
+                const auto comparison =
+                    comparison_.compare(active_estimator_->snapshot(), shadow_result.snapshot,
+                                        telemetry_.shadow_health);
+                update_shadow_telemetry_locked(comparison);
+            }
+            shadow_idle_cv_.notify_all();
+        } catch (const std::exception& ex) {
+            std::scoped_lock lock(mutex_, shadow_mutex_);
+            if (shadow_inflight_ > 0) {
+                shadow_inflight_ -= 1;
+            }
+            telemetry_.shadow_health = ShadowHealthState::FAILED;
+            telemetry_.last_failure_reason = ex.what();
+            shadow_idle_cv_.notify_all();
+        } catch (...) {
+            std::scoped_lock lock(mutex_, shadow_mutex_);
+            if (shadow_inflight_ > 0) {
+                shadow_inflight_ -= 1;
+            }
+            telemetry_.shadow_health = ShadowHealthState::FAILED;
+            telemetry_.last_failure_reason = "shadow estimator failed with unknown exception";
+            shadow_idle_cv_.notify_all();
+        }
+    }
+}
+
+void EstimatorCoordinator::update_shadow_telemetry_locked(
+    const EstimatorComparisonSnapshot& comparison) {
+    telemetry_.comparable = comparison.comparable;
+    telemetry_.position_delta_m = comparison.position_delta_m;
+    telemetry_.velocity_delta_mps = comparison.velocity_delta_mps;
+    telemetry_.orientation_delta_deg = comparison.orientation_delta_deg;
+    telemetry_.comparable_snapshot_count = comparison.comparable_snapshot_count;
+    telemetry_.skipped_comparison_count = comparison.skipped_comparison_count;
+    telemetry_.last_divergence_reason = comparison.last_divergence_reason;
+    telemetry_.divergence_active = comparison.diverged;
+    if (comparison.diverged) {
+        telemetry_.shadow_health = ShadowHealthState::DIVERGED;
+    }
+}
+
+} // namespace drone::estimation

--- a/src/estimation/MeasurementAdapters.cpp
+++ b/src/estimation/MeasurementAdapters.cpp
@@ -15,7 +15,8 @@ bool finite_vec3(const Eigen::Vector3d& value) {
 MeasurementAdapterResult MeasurementAdapters::adapt_imu(const drone::sensors::ImuMeasurement& imu,
                                                         uint64_t sequence_id) {
     MeasurementAdapterResult out;
-    if (!std::isfinite(imu.timestamp) || !finite_vec3(imu.accel_mps2) || !finite_vec3(imu.gyro_rads)) {
+    if (!std::isfinite(imu.timestamp) || !finite_vec3(imu.accel_mps2) ||
+        !finite_vec3(imu.gyro_rads)) {
         out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
         out.validation.reason = "imu measurement contains non-finite values";
         return out;
@@ -142,9 +143,8 @@ MeasurementAdapterResult MeasurementAdapters::adapt_altitude(double timestamp_s,
     return out;
 }
 
-MeasurementAdapterResult
-MeasurementAdapters::adapt_tdoa_position_candidate(double timestamp_s, const Eigen::Vector3d& position,
-                                                   double confidence, uint64_t sequence_id) {
+MeasurementAdapterResult MeasurementAdapters::adapt_tdoa_position_candidate(
+    double timestamp_s, const Eigen::Vector3d& position, double confidence, uint64_t sequence_id) {
     MeasurementAdapterResult out;
     if (!std::isfinite(timestamp_s) || !finite_vec3(position) || !std::isfinite(confidence) ||
         confidence < 0.0 || confidence > 1.0) {
@@ -181,7 +181,8 @@ MeasurementValidationResult MeasurementAdapters::validate(const EstimatorMeasure
         result.reason = "measurement frame is unsupported";
         return result;
     }
-    if (newest_timestamp_s >= 0.0 && measurement.header.timestamp_s + max_staleness_s < newest_timestamp_s) {
+    if (newest_timestamp_s >= 0.0 &&
+        measurement.header.timestamp_s + max_staleness_s < newest_timestamp_s) {
         result.status = MeasurementValidationStatus::REJECTED_STALE;
         result.reason = "measurement is stale";
         return result;

--- a/src/estimation/MeasurementAdapters.cpp
+++ b/src/estimation/MeasurementAdapters.cpp
@@ -1,0 +1,193 @@
+#include "estimation/MeasurementAdapters.hpp"
+
+#include <cmath>
+
+namespace drone::estimation {
+
+namespace {
+
+bool finite_vec3(const Eigen::Vector3d& value) {
+    return value.array().isFinite().all();
+}
+
+} // namespace
+
+MeasurementAdapterResult MeasurementAdapters::adapt_imu(const drone::sensors::ImuMeasurement& imu,
+                                                        uint64_t sequence_id) {
+    MeasurementAdapterResult out;
+    if (!std::isfinite(imu.timestamp) || !finite_vec3(imu.accel_mps2) || !finite_vec3(imu.gyro_rads)) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "imu measurement contains non-finite values";
+        return out;
+    }
+
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = imu.timestamp;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::IMU;
+    measurement.header.frame = CoordinateFrame::BODY;
+    measurement.header.type = MeasurementType::IMU;
+    measurement.data = ImuMeasurementData{imu.accel_mps2, imu.gyro_rads};
+
+    out.validation.consumed = true;
+    out.measurement = std::move(measurement);
+    return out;
+}
+
+MeasurementAdapterResult MeasurementAdapters::adapt_visual_pose(
+    double timestamp_s, const Eigen::Vector3d& position, const Eigen::Vector3d& velocity,
+    const Eigen::Quaterniond& orientation, double quality, bool update_accepted,
+    uint64_t sequence_id, bool allow_orientation_fusion) {
+    MeasurementAdapterResult out;
+    if (!std::isfinite(timestamp_s) || !finite_vec3(position) || !finite_vec3(velocity) ||
+        !std::isfinite(quality)) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "visual pose measurement contains non-finite values";
+        return out;
+    }
+    if (quality < 0.0 || quality > 1.0) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "visual pose quality is outside [0, 1]";
+        return out;
+    }
+
+    VisualPoseMeasurementData visual;
+    visual.position = position;
+    visual.velocity = velocity;
+    visual.quality = quality;
+    visual.covariance.dimension = 6;
+    visual.covariance.matrix.setZero();
+    const double sigma_position_m = std::clamp(0.50 - (quality * 0.28), 0.14, 0.50);
+    const double sigma_velocity_mps = std::clamp(0.65 - (quality * 0.30), 0.18, 0.65);
+    visual.covariance.matrix.block<3, 3>(0, 0) =
+        Eigen::Matrix3d::Identity() * sigma_position_m * sigma_position_m;
+    visual.covariance.matrix.block<3, 3>(3, 3) =
+        Eigen::Matrix3d::Identity() * sigma_velocity_mps * sigma_velocity_mps;
+
+    const double orientation_norm = orientation.norm();
+    if (!std::isfinite(orientation_norm) || std::abs(orientation_norm - 1.0) > 1.0e-3) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "visual orientation quaternion is invalid";
+        return out;
+    }
+    visual.orientation = orientation.normalized();
+    visual.orientation_consumed = allow_orientation_fusion;
+
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::VISUAL_FRONTEND;
+    measurement.header.frame = CoordinateFrame::WORLD;
+    measurement.header.type = MeasurementType::VISUAL_POSE;
+    measurement.data = std::move(visual);
+
+    out.validation.consumed = update_accepted;
+    out.validation.orientation_consumed = allow_orientation_fusion;
+    if (!update_accepted) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_OUTLIER;
+        out.validation.reason = "visual frontend rejected the pose update";
+        return out;
+    }
+    if (!allow_orientation_fusion) {
+        out.validation.reason = "visual orientation preserved but not consumed by active estimator";
+    }
+    out.measurement = std::move(measurement);
+    return out;
+}
+
+MeasurementAdapterResult MeasurementAdapters::adapt_manual_zupt(double timestamp_s,
+                                                                uint64_t sequence_id) {
+    MeasurementAdapterResult out;
+    if (!std::isfinite(timestamp_s)) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "zupt timestamp must be finite";
+        return out;
+    }
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::MANUAL_ZUPT;
+    measurement.header.frame = CoordinateFrame::BODY;
+    measurement.header.type = MeasurementType::ZERO_VELOCITY;
+    measurement.data = ZeroVelocityMeasurementData{};
+    out.validation.consumed = true;
+    out.measurement = std::move(measurement);
+    return out;
+}
+
+MeasurementAdapterResult MeasurementAdapters::adapt_altitude(double timestamp_s, double altitude_m,
+                                                             double sigma_m, CoordinateFrame frame,
+                                                             uint64_t sequence_id) {
+    MeasurementAdapterResult out;
+    if (!std::isfinite(timestamp_s) || !std::isfinite(altitude_m) || !std::isfinite(sigma_m) ||
+        sigma_m <= 0.0) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "altitude measurement is invalid";
+        return out;
+    }
+    if (frame != CoordinateFrame::WORLD && frame != CoordinateFrame::LOCAL_ENU) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_FRAME_MISMATCH;
+        out.validation.reason = "altitude frame is unsupported";
+        return out;
+    }
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::DEPTH_SENSOR;
+    measurement.header.frame = frame;
+    measurement.header.type = MeasurementType::ALTITUDE;
+    measurement.data = AltitudeMeasurementData{altitude_m, sigma_m};
+    out.validation.consumed = true;
+    out.measurement = std::move(measurement);
+    return out;
+}
+
+MeasurementAdapterResult
+MeasurementAdapters::adapt_tdoa_position_candidate(double timestamp_s, const Eigen::Vector3d& position,
+                                                   double confidence, uint64_t sequence_id) {
+    MeasurementAdapterResult out;
+    if (!std::isfinite(timestamp_s) || !finite_vec3(position) || !std::isfinite(confidence) ||
+        confidence < 0.0 || confidence > 1.0) {
+        out.validation.status = MeasurementValidationStatus::REJECTED_INVALID;
+        out.validation.reason = "tdoa position candidate is invalid";
+        return out;
+    }
+
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::TDOA_HEURISTIC;
+    measurement.header.frame = CoordinateFrame::WORLD;
+    measurement.header.type = MeasurementType::TDOA_POSITION_CANDIDATE;
+    measurement.data = TdoaPositionMeasurementData{position, confidence, true};
+
+    out.validation.status = MeasurementValidationStatus::IGNORED_SHADOW_ONLY;
+    out.validation.reason = "tdoa candidate remains heuristic-only in phase 16";
+    out.measurement = std::move(measurement);
+    return out;
+}
+
+MeasurementValidationResult MeasurementAdapters::validate(const EstimatorMeasurement& measurement,
+                                                          double newest_timestamp_s,
+                                                          double max_staleness_s) {
+    MeasurementValidationResult result;
+    if (!std::isfinite(measurement.header.timestamp_s)) {
+        result.status = MeasurementValidationStatus::REJECTED_INVALID;
+        result.reason = "measurement timestamp must be finite";
+        return result;
+    }
+    if (measurement.header.frame == CoordinateFrame::UNKNOWN) {
+        result.status = MeasurementValidationStatus::REJECTED_UNSUPPORTED;
+        result.reason = "measurement frame is unsupported";
+        return result;
+    }
+    if (newest_timestamp_s >= 0.0 && measurement.header.timestamp_s + max_staleness_s < newest_timestamp_s) {
+        result.status = MeasurementValidationStatus::REJECTED_STALE;
+        result.reason = "measurement is stale";
+        return result;
+    }
+    result.consumed = true;
+    return result;
+}
+
+} // namespace drone::estimation

--- a/src/estimation/MinimalEskfAdapter.cpp
+++ b/src/estimation/MinimalEskfAdapter.cpp
@@ -1,0 +1,114 @@
+#include "estimation/MinimalEskfAdapter.hpp"
+
+#include <cmath>
+
+namespace drone::estimation {
+
+MinimalEskfAdapter::MinimalEskfAdapter(drone::vio::EKFConfig config) : estimator_(config) {
+    estimator_.set_validation_config(validation_);
+}
+
+void MinimalEskfAdapter::set_validation_config(const drone::vio::EstimatorValidationConfig& config) {
+    validation_ = config;
+    estimator_.set_validation_config(validation_);
+}
+
+void MinimalEskfAdapter::reset(const EstimatorInitialState& initial) {
+    estimator_.reset(initial.position, initial.orientation, initial.velocity);
+    estimator_.set_validation_config(validation_);
+    last_sequence_id_ = 0;
+    last_timestamp_s_ = -1.0;
+}
+
+EstimatorUpdateResult MinimalEskfAdapter::process(const EstimatorMeasurement& measurement) {
+    EstimatorUpdateResult result;
+    if (last_timestamp_s_ >= 0.0 && measurement.header.timestamp_s < last_timestamp_s_) {
+        return unsupported_result(measurement, MeasurementValidationStatus::REJECTED_STALE,
+                                  "measurement timestamp moved backwards");
+    }
+
+    result.validation.consumed = true;
+    result.status = EstimatorUpdateStatus::ACCEPTED;
+    switch (measurement.header.type) {
+    case MeasurementType::IMU: {
+        const auto& imu = std::get<ImuMeasurementData>(measurement.data);
+        const double dt = last_timestamp_s_ >= 0.0 ? (measurement.header.timestamp_s - last_timestamp_s_) : 0.0025;
+        estimator_.propagate_imu(imu.acceleration_mps2, imu.angular_velocity_rads, dt);
+        break;
+    }
+    case MeasurementType::VISUAL_POSE: {
+        const auto& visual = std::get<VisualPoseMeasurementData>(measurement.data);
+        estimator_.update_visual_pose(
+            visual.position, visual.velocity,
+            std::sqrt(std::max(0.0, visual.covariance.matrix(0, 0))),
+            std::sqrt(std::max(0.0, visual.covariance.matrix(3, 3))));
+        result.validation.orientation_consumed = false;
+        if (visual.orientation.has_value()) {
+            result.validation.reason =
+                "visual orientation preserved but not fused by minimal ESKF adapter";
+        }
+        break;
+    }
+    case MeasurementType::ALTITUDE: {
+        const auto& altitude = std::get<AltitudeMeasurementData>(measurement.data);
+        estimator_.update_depth(altitude.altitude_m, altitude.sigma_m);
+        break;
+    }
+    case MeasurementType::ZERO_VELOCITY:
+        estimator_.update_zupt();
+        break;
+    case MeasurementType::TDOA_POSITION_CANDIDATE:
+        return unsupported_result(measurement, MeasurementValidationStatus::IGNORED_SHADOW_ONLY,
+                                  "tdoa candidate is not a mathematically valid ESKF update");
+    default:
+        return unsupported_result(measurement, MeasurementValidationStatus::REJECTED_UNSUPPORTED,
+                                  "measurement type unsupported by minimal ESKF");
+    }
+
+    last_sequence_id_ = measurement.header.sequence_id;
+    last_timestamp_s_ = measurement.header.timestamp_s;
+    result.snapshot = snapshot();
+    return result;
+}
+
+EstimatorSnapshot MinimalEskfAdapter::snapshot() const {
+    EstimatorSnapshot out;
+    out.pose = estimator_.state();
+    out.diagnostics = estimator_.diagnostics();
+    out.last_sequence_id = last_sequence_id_;
+    return out;
+}
+
+drone::vio::EstimatorDiagnostics MinimalEskfAdapter::diagnostics() const {
+    return estimator_.diagnostics();
+}
+
+EstimatorCapabilities MinimalEskfAdapter::capabilities() const {
+    EstimatorCapabilities capabilities;
+    capabilities.set(EstimatorCapability::IMU_PROPAGATION);
+    capabilities.set(EstimatorCapability::VISUAL_POSITION_UPDATE);
+    capabilities.set(EstimatorCapability::VISUAL_VELOCITY_UPDATE);
+    capabilities.set(EstimatorCapability::DEPTH_UPDATE);
+    capabilities.set(EstimatorCapability::ZERO_VELOCITY_UPDATE);
+    return capabilities;
+}
+
+std::string_view MinimalEskfAdapter::name() const noexcept {
+    return "minimal_eskf";
+}
+
+EstimatorUpdateResult MinimalEskfAdapter::unsupported_result(const EstimatorMeasurement& measurement,
+                                                             MeasurementValidationStatus status,
+                                                             std::string reason) const {
+    EstimatorUpdateResult result;
+    result.status = status == MeasurementValidationStatus::IGNORED_SHADOW_ONLY
+                        ? EstimatorUpdateStatus::IGNORED
+                        : EstimatorUpdateStatus::REJECTED;
+    result.validation.status = status;
+    result.validation.reason = std::move(reason);
+    result.snapshot = snapshot();
+    result.snapshot.last_sequence_id = measurement.header.sequence_id;
+    return result;
+}
+
+} // namespace drone::estimation

--- a/src/estimation/MinimalEskfAdapter.cpp
+++ b/src/estimation/MinimalEskfAdapter.cpp
@@ -8,7 +8,8 @@ MinimalEskfAdapter::MinimalEskfAdapter(drone::vio::EKFConfig config) : estimator
     estimator_.set_validation_config(validation_);
 }
 
-void MinimalEskfAdapter::set_validation_config(const drone::vio::EstimatorValidationConfig& config) {
+void MinimalEskfAdapter::set_validation_config(
+    const drone::vio::EstimatorValidationConfig& config) {
     validation_ = config;
     estimator_.set_validation_config(validation_);
 }
@@ -32,16 +33,17 @@ EstimatorUpdateResult MinimalEskfAdapter::process(const EstimatorMeasurement& me
     switch (measurement.header.type) {
     case MeasurementType::IMU: {
         const auto& imu = std::get<ImuMeasurementData>(measurement.data);
-        const double dt = last_timestamp_s_ >= 0.0 ? (measurement.header.timestamp_s - last_timestamp_s_) : 0.0025;
+        const double dt = last_timestamp_s_ >= 0.0
+                              ? (measurement.header.timestamp_s - last_timestamp_s_)
+                              : 0.0025;
         estimator_.propagate_imu(imu.acceleration_mps2, imu.angular_velocity_rads, dt);
         break;
     }
     case MeasurementType::VISUAL_POSE: {
         const auto& visual = std::get<VisualPoseMeasurementData>(measurement.data);
-        estimator_.update_visual_pose(
-            visual.position, visual.velocity,
-            std::sqrt(std::max(0.0, visual.covariance.matrix(0, 0))),
-            std::sqrt(std::max(0.0, visual.covariance.matrix(3, 3))));
+        estimator_.update_visual_pose(visual.position, visual.velocity,
+                                      std::sqrt(std::max(0.0, visual.covariance.matrix(0, 0))),
+                                      std::sqrt(std::max(0.0, visual.covariance.matrix(3, 3))));
         result.validation.orientation_consumed = false;
         if (visual.orientation.has_value()) {
             result.validation.reason =
@@ -97,9 +99,10 @@ std::string_view MinimalEskfAdapter::name() const noexcept {
     return "minimal_eskf";
 }
 
-EstimatorUpdateResult MinimalEskfAdapter::unsupported_result(const EstimatorMeasurement& measurement,
-                                                             MeasurementValidationStatus status,
-                                                             std::string reason) const {
+EstimatorUpdateResult
+MinimalEskfAdapter::unsupported_result(const EstimatorMeasurement& measurement,
+                                       MeasurementValidationStatus status,
+                                       std::string reason) const {
     EstimatorUpdateResult result;
     result.status = status == MeasurementValidationStatus::IGNORED_SHADOW_ONLY
                         ? EstimatorUpdateStatus::IGNORED

--- a/src/estimation/ReplayRunner.cpp
+++ b/src/estimation/ReplayRunner.cpp
@@ -18,8 +18,7 @@ namespace {
 
 using json = nlohmann::json;
 
-template <typename T, size_t N>
-std::array<T, N> require_array(const json& node, const char* key) {
+template <typename T, size_t N> std::array<T, N> require_array(const json& node, const char* key) {
     if (!node.contains(key) || !node.at(key).is_array() || node.at(key).size() != N) {
         throw std::runtime_error(std::string(key) + " must be an array of length " +
                                  std::to_string(N));
@@ -121,12 +120,18 @@ std::string fixed_scalar(double value) {
 
 std::string canonical_hash_payload(const ReplayReport& report) {
     std::ostringstream oss;
-    oss << report.report_schema_version << '\n' << report.replay_input_schema_version << '\n'
-        << report.replay_mode << '\n' << report.active_estimator_name << '\n'
-        << report.shadow_estimator_name << '\n' << report.coordinate_frame << '\n'
-        << report.input_record_count << '\n' << report.processed_record_count << '\n'
-        << report.accepted_update_count << '\n' << report.rejected_update_count << '\n'
-        << report.invalid_record_count << '\n' << report.timestamp_violation_count << '\n'
+    oss << report.report_schema_version << '\n'
+        << report.replay_input_schema_version << '\n'
+        << report.replay_mode << '\n'
+        << report.active_estimator_name << '\n'
+        << report.shadow_estimator_name << '\n'
+        << report.coordinate_frame << '\n'
+        << report.input_record_count << '\n'
+        << report.processed_record_count << '\n'
+        << report.accepted_update_count << '\n'
+        << report.rejected_update_count << '\n'
+        << report.invalid_record_count << '\n'
+        << report.timestamp_violation_count << '\n'
         << report.unsupported_measurement_count << '\n'
         << fixed_scalar(report.final_pose.position.x()) << '\n'
         << fixed_scalar(report.final_pose.position.y()) << '\n'
@@ -150,14 +155,18 @@ std::string canonical_hash_payload(const ReplayReport& report) {
         << fixed_scalar(report.active_shadow_position_delta_m) << '\n'
         << fixed_scalar(report.active_shadow_velocity_delta_mps) << '\n'
         << fixed_scalar(report.active_shadow_orientation_delta_deg) << '\n'
-        << report.comparable_snapshot_count << '\n' << report.skipped_comparison_count << '\n'
-        << report.shadow_dropped_event_count << '\n' << report.shadow_queue_high_water_mark << '\n'
+        << report.comparable_snapshot_count << '\n'
+        << report.skipped_comparison_count << '\n'
+        << report.shadow_dropped_event_count << '\n'
+        << report.shadow_queue_high_water_mark << '\n'
         << report.shadow_synchronization_state << '\n'
-        << (report.success ? "1" : "0") << '\n' << report.failure_reason << '\n';
+        << (report.success ? "1" : "0") << '\n'
+        << report.failure_reason << '\n';
     return oss.str();
 }
 
-EstimatorMeasurement make_measurement_from_record(const json& record, CoordinateFrame coordinate_frame,
+EstimatorMeasurement make_measurement_from_record(const json& record,
+                                                  CoordinateFrame coordinate_frame,
                                                   uint64_t sequence_id, size_t max_string_length,
                                                   uint64_t& unsupported_count) {
     const auto type = require_string_bounded(record, "type", max_string_length);
@@ -167,8 +176,8 @@ EstimatorMeasurement make_measurement_from_record(const json& record, Coordinate
         EstimatorMeasurement measurement;
         measurement.header = {timestamp_s, sequence_id, SensorSource::IMU, CoordinateFrame::BODY,
                               MeasurementType::IMU};
-        measurement.data =
-            ImuMeasurementData{require_vec3(record, "accel_mps2"), require_vec3(record, "gyro_rads")};
+        measurement.data = ImuMeasurementData{require_vec3(record, "accel_mps2"),
+                                              require_vec3(record, "gyro_rads")};
         return measurement;
     }
     if (type == "visual_pose") {
@@ -236,8 +245,8 @@ EstimatorMeasurement make_measurement_from_record(const json& record, Coordinate
         if (confidence < 0.0 || confidence > 1.0) {
             throw std::runtime_error("confidence must be within [0, 1]");
         }
-        measurement.data = TdoaPositionMeasurementData{require_vec3(record, "position_m"),
-                                                       confidence, true};
+        measurement.data =
+            TdoaPositionMeasurementData{require_vec3(record, "position_m"), confidence, true};
         return measurement;
     }
     if (type == "ground_truth") {
@@ -281,7 +290,8 @@ ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
             throw std::runtime_error("replay input file could not be opened");
         }
         json payload = json::parse(input, nullptr, true, true);
-        report.replay_input_schema_version = payload.value("schema_version", payload.value("version", 0));
+        report.replay_input_schema_version =
+            payload.value("schema_version", payload.value("version", 0));
         if (report.replay_input_schema_version != 1) {
             throw std::runtime_error("unsupported replay schema version");
         }
@@ -319,7 +329,8 @@ ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
         if (config.mode == ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW) {
             ShadowEstimatorConfig shadow_config;
             shadow_config.enabled = true;
-            shadow_config.max_queue_depth = std::max<size_t>(8, config.validation.shadow_max_queue_depth);
+            shadow_config.max_queue_depth =
+                std::max<size_t>(8, config.validation.shadow_max_queue_depth);
             shadow_config.max_lag_ms = std::max(1.0, config.validation.shadow_max_lag_ms);
             auto shadow = std::make_unique<MinimalEskfAdapter>(config.ekf_config);
             shadow->set_validation_config(config.validation);
@@ -341,10 +352,9 @@ ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
                 require_finite_number(record, "timestamp_s");
                 continue;
             }
-            EstimatorMeasurement measurement =
-                make_measurement_from_record(record, coordinate_frame, ++sequence_id,
-                                             config.limits.max_string_length,
-                                             report.unsupported_measurement_count);
+            EstimatorMeasurement measurement = make_measurement_from_record(
+                record, coordinate_frame, ++sequence_id, config.limits.max_string_length,
+                report.unsupported_measurement_count);
             if (last_timestamp_s >= 0.0 && measurement.header.timestamp_s <= last_timestamp_s) {
                 report.timestamp_violation_count += 1;
                 throw std::runtime_error("timestamps must be strictly monotonic");
@@ -400,7 +410,8 @@ ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
         report.maximum_propagation_latency_us = active_snapshot.diagnostics.max_update_latency_us;
         report.average_measurement_update_latency_us =
             active_snapshot.diagnostics.average_measurement_latency_us;
-        report.maximum_measurement_update_latency_us = active_snapshot.diagnostics.max_update_latency_us;
+        report.maximum_measurement_update_latency_us =
+            active_snapshot.diagnostics.max_update_latency_us;
         report.success = true;
         report.failure_reason = "none";
         report.deterministic_result_hash = security::sha3_hex(canonical_hash_payload(report));
@@ -435,10 +446,9 @@ std::string replay_report_json(const ReplayReport& report) {
                                   report.final_pose.position.z()};
     output["final_velocity_mps"] = {report.final_pose.velocity.x(), report.final_pose.velocity.y(),
                                     report.final_pose.velocity.z()};
-    output["final_orientation_wxyz"] = {report.final_pose.orientation.w(),
-                                        report.final_pose.orientation.x(),
-                                        report.final_pose.orientation.y(),
-                                        report.final_pose.orientation.z()};
+    output["final_orientation_wxyz"] = {
+        report.final_pose.orientation.w(), report.final_pose.orientation.x(),
+        report.final_pose.orientation.y(), report.final_pose.orientation.z()};
     output["final_accel_bias_mps2"] = {report.final_pose.accel_bias.x(),
                                        report.final_pose.accel_bias.y(),
                                        report.final_pose.accel_bias.z()};

--- a/src/estimation/ReplayRunner.cpp
+++ b/src/estimation/ReplayRunner.cpp
@@ -1,0 +1,469 @@
+#include "estimation/ReplayRunner.hpp"
+
+#include "security/FirmwareTrust.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+
+namespace drone::estimation {
+
+namespace {
+
+using json = nlohmann::json;
+
+template <typename T, size_t N>
+std::array<T, N> require_array(const json& node, const char* key) {
+    if (!node.contains(key) || !node.at(key).is_array() || node.at(key).size() != N) {
+        throw std::runtime_error(std::string(key) + " must be an array of length " +
+                                 std::to_string(N));
+    }
+    std::array<T, N> out{};
+    for (size_t i = 0; i < N; ++i) {
+        out[i] = node.at(key).at(i).get<T>();
+        if constexpr (std::is_floating_point_v<T>) {
+            if (!std::isfinite(out[i])) {
+                throw std::runtime_error(std::string(key) + " must contain finite values");
+            }
+        }
+    }
+    return out;
+}
+
+Eigen::Vector3d require_vec3(const json& node, const char* key) {
+    const auto values = require_array<double, 3>(node, key);
+    return Eigen::Vector3d{values[0], values[1], values[2]};
+}
+
+double require_finite_number(const json& node, const char* key) {
+    if (!node.contains(key) || !node.at(key).is_number()) {
+        throw std::runtime_error(std::string(key) + " must be a number");
+    }
+    const double value = node.at(key).get<double>();
+    if (!std::isfinite(value)) {
+        throw std::runtime_error(std::string(key) + " must be finite");
+    }
+    return value;
+}
+
+std::string require_string_bounded(const json& node, const char* key, size_t max_length) {
+    if (!node.contains(key) || !node.at(key).is_string()) {
+        throw std::runtime_error(std::string(key) + " must be a string");
+    }
+    const auto value = node.at(key).get<std::string>();
+    if (value.empty() || value.size() > max_length) {
+        throw std::runtime_error(std::string(key) + " length is invalid");
+    }
+    return value;
+}
+
+CoordinateFrame parse_coordinate_frame(std::string_view frame) {
+    if (frame == "world" || frame == "local_enu") {
+        return CoordinateFrame::WORLD;
+    }
+    if (frame == "body") {
+        return CoordinateFrame::BODY;
+    }
+    throw std::runtime_error("unsupported coordinate frame");
+}
+
+std::string health_to_string(drone::vio::EstimatorHealthState state) {
+    switch (state) {
+    case drone::vio::EstimatorHealthState::INITIALIZING:
+        return "initializing";
+    case drone::vio::EstimatorHealthState::NOMINAL:
+        return "nominal";
+    case drone::vio::EstimatorHealthState::DEGRADED:
+        return "degraded";
+    case drone::vio::EstimatorHealthState::REJECTING_MEASUREMENTS:
+        return "rejecting_measurements";
+    case drone::vio::EstimatorHealthState::NUMERICAL_WARNING:
+        return "numerical_warning";
+    case drone::vio::EstimatorHealthState::INVALID:
+        return "invalid";
+    }
+    return "unknown";
+}
+
+std::string shadow_to_string(ShadowHealthState state) {
+    switch (state) {
+    case ShadowHealthState::DISABLED:
+        return "disabled";
+    case ShadowHealthState::STARTING:
+        return "starting";
+    case ShadowHealthState::SYNCHRONIZED:
+        return "synchronized";
+    case ShadowHealthState::LAGGING:
+        return "lagging";
+    case ShadowHealthState::STALE:
+        return "stale";
+    case ShadowHealthState::DIVERGED:
+        return "diverged";
+    case ShadowHealthState::FAILED:
+        return "failed";
+    case ShadowHealthState::STOPPED:
+        return "stopped";
+    }
+    return "unknown";
+}
+
+std::string fixed_scalar(double value) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(12) << value;
+    return oss.str();
+}
+
+std::string canonical_hash_payload(const ReplayReport& report) {
+    std::ostringstream oss;
+    oss << report.report_schema_version << '\n' << report.replay_input_schema_version << '\n'
+        << report.replay_mode << '\n' << report.active_estimator_name << '\n'
+        << report.shadow_estimator_name << '\n' << report.coordinate_frame << '\n'
+        << report.input_record_count << '\n' << report.processed_record_count << '\n'
+        << report.accepted_update_count << '\n' << report.rejected_update_count << '\n'
+        << report.invalid_record_count << '\n' << report.timestamp_violation_count << '\n'
+        << report.unsupported_measurement_count << '\n'
+        << fixed_scalar(report.final_pose.position.x()) << '\n'
+        << fixed_scalar(report.final_pose.position.y()) << '\n'
+        << fixed_scalar(report.final_pose.position.z()) << '\n'
+        << fixed_scalar(report.final_pose.velocity.x()) << '\n'
+        << fixed_scalar(report.final_pose.velocity.y()) << '\n'
+        << fixed_scalar(report.final_pose.velocity.z()) << '\n'
+        << fixed_scalar(report.final_pose.orientation.w()) << '\n'
+        << fixed_scalar(report.final_pose.orientation.x()) << '\n'
+        << fixed_scalar(report.final_pose.orientation.y()) << '\n'
+        << fixed_scalar(report.final_pose.orientation.z()) << '\n'
+        << fixed_scalar(report.final_pose.accel_bias.x()) << '\n'
+        << fixed_scalar(report.final_pose.accel_bias.y()) << '\n'
+        << fixed_scalar(report.final_pose.accel_bias.z()) << '\n'
+        << fixed_scalar(report.final_pose.gyro_bias.x()) << '\n'
+        << fixed_scalar(report.final_pose.gyro_bias.y()) << '\n'
+        << fixed_scalar(report.final_pose.gyro_bias.z()) << '\n'
+        << fixed_scalar(report.final_position_uncertainty_m) << '\n'
+        << report.active_estimator_health << '\n'
+        << report.shadow_estimator_health << '\n'
+        << fixed_scalar(report.active_shadow_position_delta_m) << '\n'
+        << fixed_scalar(report.active_shadow_velocity_delta_mps) << '\n'
+        << fixed_scalar(report.active_shadow_orientation_delta_deg) << '\n'
+        << report.comparable_snapshot_count << '\n' << report.skipped_comparison_count << '\n'
+        << report.shadow_dropped_event_count << '\n' << report.shadow_queue_high_water_mark << '\n'
+        << report.shadow_synchronization_state << '\n'
+        << (report.success ? "1" : "0") << '\n' << report.failure_reason << '\n';
+    return oss.str();
+}
+
+EstimatorMeasurement make_measurement_from_record(const json& record, CoordinateFrame coordinate_frame,
+                                                  uint64_t sequence_id, size_t max_string_length,
+                                                  uint64_t& unsupported_count) {
+    const auto type = require_string_bounded(record, "type", max_string_length);
+    const double timestamp_s = require_finite_number(record, "timestamp_s");
+
+    if (type == "imu") {
+        EstimatorMeasurement measurement;
+        measurement.header = {timestamp_s, sequence_id, SensorSource::IMU, CoordinateFrame::BODY,
+                              MeasurementType::IMU};
+        measurement.data =
+            ImuMeasurementData{require_vec3(record, "accel_mps2"), require_vec3(record, "gyro_rads")};
+        return measurement;
+    }
+    if (type == "visual_pose") {
+        EstimatorMeasurement measurement;
+        measurement.header = {timestamp_s, sequence_id, SensorSource::VISUAL_FRONTEND,
+                              coordinate_frame, MeasurementType::VISUAL_POSE};
+        VisualPoseMeasurementData visual;
+        visual.position = require_vec3(record, "position_m");
+        visual.velocity = require_vec3(record, "velocity_mps");
+        visual.quality = 1.0;
+        if (record.contains("quality")) {
+            visual.quality = require_finite_number(record, "quality");
+            if (visual.quality < 0.0 || visual.quality > 1.0) {
+                throw std::runtime_error("quality must be within [0, 1]");
+            }
+        }
+        const double sigma_position_m = require_finite_number(record, "sigma_position_m");
+        const double sigma_velocity_mps = require_finite_number(record, "sigma_velocity_mps");
+        if (sigma_position_m <= 0.0 || sigma_velocity_mps <= 0.0) {
+            throw std::runtime_error("visual pose sigma must be positive");
+        }
+        visual.covariance.dimension = 6;
+        visual.covariance.matrix.setZero();
+        visual.covariance.matrix.block<3, 3>(0, 0) =
+            Eigen::Matrix3d::Identity() * sigma_position_m * sigma_position_m;
+        visual.covariance.matrix.block<3, 3>(3, 3) =
+            Eigen::Matrix3d::Identity() * sigma_velocity_mps * sigma_velocity_mps;
+        if (record.contains("orientation_wxyz")) {
+            const auto q = require_array<double, 4>(record, "orientation_wxyz");
+            Eigen::Quaterniond orientation(q[0], q[1], q[2], q[3]);
+            if (!std::isfinite(orientation.norm()) || orientation.norm() < 1.0e-12) {
+                throw std::runtime_error("orientation_wxyz is invalid");
+            }
+            visual.orientation = orientation.normalized();
+        }
+        measurement.data = std::move(visual);
+        return measurement;
+    }
+    if (type == "depth" || type == "altitude") {
+        EstimatorMeasurement measurement;
+        measurement.header = {timestamp_s, sequence_id, SensorSource::DEPTH_SENSOR,
+                              coordinate_frame, MeasurementType::ALTITUDE};
+        const double altitude = record.contains("z_world_m")
+                                    ? require_finite_number(record, "z_world_m")
+                                    : require_finite_number(record, "altitude_m");
+        const double sigma_m = require_finite_number(record, "sigma_m");
+        if (sigma_m <= 0.0) {
+            throw std::runtime_error("sigma_m must be positive");
+        }
+        measurement.data = AltitudeMeasurementData{altitude, sigma_m};
+        return measurement;
+    }
+    if (type == "zupt") {
+        EstimatorMeasurement measurement;
+        measurement.header = {timestamp_s, sequence_id, SensorSource::MANUAL_ZUPT,
+                              CoordinateFrame::BODY, MeasurementType::ZERO_VELOCITY};
+        measurement.data = ZeroVelocityMeasurementData{};
+        return measurement;
+    }
+    if (type == "tdoa_candidate") {
+        EstimatorMeasurement measurement;
+        measurement.header = {timestamp_s, sequence_id, SensorSource::TDOA_HEURISTIC,
+                              coordinate_frame, MeasurementType::TDOA_POSITION_CANDIDATE};
+        const double confidence = require_finite_number(record, "confidence");
+        if (confidence < 0.0 || confidence > 1.0) {
+            throw std::runtime_error("confidence must be within [0, 1]");
+        }
+        measurement.data = TdoaPositionMeasurementData{require_vec3(record, "position_m"),
+                                                       confidence, true};
+        return measurement;
+    }
+    if (type == "ground_truth") {
+        unsupported_count += 1;
+        throw std::runtime_error("ground_truth records are metadata and not estimator inputs");
+    }
+
+    unsupported_count += 1;
+    throw std::runtime_error("unsupported measurement type");
+}
+
+} // namespace
+
+std::string to_string(ReplayMode mode) {
+    switch (mode) {
+    case ReplayMode::ACTIVE_ONLY:
+        return "active_only";
+    case ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW:
+        return "active_with_identical_shadow";
+    }
+    return "active_only";
+}
+
+ReplayRunResult run_replay_file(const std::filesystem::path& input_path,
+                                const ReplayRunConfig& config) {
+    ReplayRunResult result;
+    auto& report = result.report;
+    report.replay_mode = to_string(config.mode);
+
+    try {
+        if (input_path.empty() || !std::filesystem::exists(input_path)) {
+            throw std::runtime_error("replay input file not found");
+        }
+        const auto file_size = std::filesystem::file_size(input_path);
+        if (file_size > config.limits.max_file_bytes) {
+            throw std::runtime_error("replay input exceeds size limit");
+        }
+
+        std::ifstream input(input_path, std::ios::binary);
+        if (!input.is_open()) {
+            throw std::runtime_error("replay input file could not be opened");
+        }
+        json payload = json::parse(input, nullptr, true, true);
+        report.replay_input_schema_version = payload.value("schema_version", payload.value("version", 0));
+        if (report.replay_input_schema_version != 1) {
+            throw std::runtime_error("unsupported replay schema version");
+        }
+
+        const auto coordinate_frame_text =
+            payload.value("coordinate_frame", std::string("local_enu"));
+        if (coordinate_frame_text.size() > config.limits.max_string_length) {
+            throw std::runtime_error("coordinate_frame length is invalid");
+        }
+        report.coordinate_frame = coordinate_frame_text;
+        const auto coordinate_frame = parse_coordinate_frame(coordinate_frame_text);
+
+        if (!payload.contains("records") || !payload.at("records").is_array()) {
+            throw std::runtime_error("records must be an array");
+        }
+        report.input_record_count = payload.at("records").size();
+        if (report.input_record_count > config.limits.max_record_count) {
+            throw std::runtime_error("replay record count exceeds limit");
+        }
+
+        EstimatorInitialState initial{};
+        if (payload.contains("initial_state") && payload.at("initial_state").is_object()) {
+            const auto& initial_state = payload.at("initial_state");
+            initial.position = require_vec3(initial_state, "position");
+            initial.velocity = require_vec3(initial_state, "velocity");
+            const double yaw_rad = require_finite_number(initial_state, "yaw_rad");
+            initial.orientation =
+                Eigen::Quaterniond(Eigen::AngleAxisd(yaw_rad, Eigen::Vector3d::UnitZ()));
+        }
+
+        auto active = std::make_shared<MinimalEskfAdapter>(config.ekf_config);
+        active->set_validation_config(config.validation);
+        EstimatorCoordinator coordinator(std::static_pointer_cast<StateEstimator>(active));
+        coordinator.reset(initial);
+        if (config.mode == ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW) {
+            ShadowEstimatorConfig shadow_config;
+            shadow_config.enabled = true;
+            shadow_config.max_queue_depth = std::max<size_t>(8, config.validation.shadow_max_queue_depth);
+            shadow_config.max_lag_ms = std::max(1.0, config.validation.shadow_max_lag_ms);
+            auto shadow = std::make_unique<MinimalEskfAdapter>(config.ekf_config);
+            shadow->set_validation_config(config.validation);
+            coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+            report.shadow_estimator_name = "minimal_eskf";
+        }
+
+        double last_timestamp_s = -1.0;
+        uint64_t sequence_id = 0;
+        for (const auto& record : payload.at("records")) {
+            if (!record.is_object()) {
+                throw std::runtime_error("record must be an object");
+            }
+            const auto type = record.value("type", std::string());
+            if (type == "ground_truth") {
+                if (!record.contains("timestamp_s")) {
+                    throw std::runtime_error("ground_truth record missing timestamp");
+                }
+                require_finite_number(record, "timestamp_s");
+                continue;
+            }
+            EstimatorMeasurement measurement =
+                make_measurement_from_record(record, coordinate_frame, ++sequence_id,
+                                             config.limits.max_string_length,
+                                             report.unsupported_measurement_count);
+            if (last_timestamp_s >= 0.0 && measurement.header.timestamp_s <= last_timestamp_s) {
+                report.timestamp_violation_count += 1;
+                throw std::runtime_error("timestamps must be strictly monotonic");
+            }
+            last_timestamp_s = measurement.header.timestamp_s;
+            const auto update = coordinator.process(measurement);
+            report.processed_record_count += 1;
+            if (update.status == EstimatorUpdateStatus::ACCEPTED) {
+                report.accepted_update_count += 1;
+            } else {
+                report.rejected_update_count += 1;
+            }
+            if (update.validation.status == MeasurementValidationStatus::REJECTED_UNSUPPORTED) {
+                report.unsupported_measurement_count += 1;
+            }
+        }
+
+        if (config.mode == ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW) {
+            if (!coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000))) {
+                throw std::runtime_error("shadow replay did not drain within timeout");
+            }
+        }
+
+        const auto active_snapshot = coordinator.active_snapshot();
+        const auto telemetry = coordinator.telemetry();
+        const auto shadow_snapshot = coordinator.shadow_snapshot();
+        report.final_pose = active_snapshot.pose;
+        report.final_position_uncertainty_m = active_snapshot.pose.pos_std.norm();
+        report.active_estimator_health = health_to_string(active_snapshot.diagnostics.health_state);
+        report.shadow_estimator_health = shadow_to_string(telemetry.shadow_health);
+        if (shadow_snapshot.has_value()) {
+            report.active_shadow_position_delta_m =
+                (active_snapshot.pose.position - shadow_snapshot->pose.position).norm();
+            report.active_shadow_velocity_delta_mps =
+                (active_snapshot.pose.velocity - shadow_snapshot->pose.velocity).norm();
+            report.active_shadow_orientation_delta_deg =
+                Eigen::AngleAxisd(active_snapshot.pose.orientation.conjugate() *
+                                  shadow_snapshot->pose.orientation)
+                    .angle() *
+                (180.0 / std::numbers::pi_v<double>);
+        } else {
+            report.active_shadow_position_delta_m = telemetry.position_delta_m;
+            report.active_shadow_velocity_delta_mps = telemetry.velocity_delta_mps;
+            report.active_shadow_orientation_delta_deg = telemetry.orientation_delta_deg;
+        }
+        report.comparable_snapshot_count = telemetry.comparable_snapshot_count;
+        report.skipped_comparison_count = telemetry.skipped_comparison_count;
+        report.shadow_dropped_event_count = telemetry.dropped_events;
+        report.shadow_queue_high_water_mark = telemetry.queue_high_water_mark;
+        report.shadow_synchronization_state = shadow_to_string(telemetry.shadow_health);
+        report.average_propagation_latency_us =
+            active_snapshot.diagnostics.average_propagation_latency_us;
+        report.maximum_propagation_latency_us = active_snapshot.diagnostics.max_update_latency_us;
+        report.average_measurement_update_latency_us =
+            active_snapshot.diagnostics.average_measurement_latency_us;
+        report.maximum_measurement_update_latency_us = active_snapshot.diagnostics.max_update_latency_us;
+        report.success = true;
+        report.failure_reason = "none";
+        report.deterministic_result_hash = security::sha3_hex(canonical_hash_payload(report));
+        result.exit_code = 0;
+        coordinator.stop_shadow();
+    } catch (const std::exception& ex) {
+        report.success = false;
+        report.failure_reason = ex.what();
+        report.deterministic_result_hash = security::sha3_hex(canonical_hash_payload(report));
+        result.exit_code = 1;
+    }
+
+    return result;
+}
+
+std::string replay_report_json(const ReplayReport& report) {
+    json output;
+    output["report_schema_version"] = report.report_schema_version;
+    output["replay_input_schema_version"] = report.replay_input_schema_version;
+    output["replay_mode"] = report.replay_mode;
+    output["active_estimator_name"] = report.active_estimator_name;
+    output["shadow_estimator_name"] = report.shadow_estimator_name;
+    output["coordinate_frame"] = report.coordinate_frame;
+    output["input_record_count"] = report.input_record_count;
+    output["processed_record_count"] = report.processed_record_count;
+    output["accepted_update_count"] = report.accepted_update_count;
+    output["rejected_update_count"] = report.rejected_update_count;
+    output["invalid_record_count"] = report.invalid_record_count;
+    output["timestamp_violation_count"] = report.timestamp_violation_count;
+    output["unsupported_measurement_count"] = report.unsupported_measurement_count;
+    output["final_position_m"] = {report.final_pose.position.x(), report.final_pose.position.y(),
+                                  report.final_pose.position.z()};
+    output["final_velocity_mps"] = {report.final_pose.velocity.x(), report.final_pose.velocity.y(),
+                                    report.final_pose.velocity.z()};
+    output["final_orientation_wxyz"] = {report.final_pose.orientation.w(),
+                                        report.final_pose.orientation.x(),
+                                        report.final_pose.orientation.y(),
+                                        report.final_pose.orientation.z()};
+    output["final_accel_bias_mps2"] = {report.final_pose.accel_bias.x(),
+                                       report.final_pose.accel_bias.y(),
+                                       report.final_pose.accel_bias.z()};
+    output["final_gyro_bias_rads"] = {report.final_pose.gyro_bias.x(),
+                                      report.final_pose.gyro_bias.y(),
+                                      report.final_pose.gyro_bias.z()};
+    output["final_estimated_position_uncertainty_m"] = report.final_position_uncertainty_m;
+    output["active_estimator_health"] = report.active_estimator_health;
+    output["shadow_estimator_health"] = report.shadow_estimator_health;
+    output["active_shadow_position_delta_m"] = report.active_shadow_position_delta_m;
+    output["active_shadow_velocity_delta_mps"] = report.active_shadow_velocity_delta_mps;
+    output["active_shadow_orientation_delta_deg"] = report.active_shadow_orientation_delta_deg;
+    output["comparable_snapshot_count"] = report.comparable_snapshot_count;
+    output["skipped_comparison_count"] = report.skipped_comparison_count;
+    output["shadow_dropped_event_count"] = report.shadow_dropped_event_count;
+    output["shadow_queue_high_water_mark"] = report.shadow_queue_high_water_mark;
+    output["shadow_synchronization_state"] = report.shadow_synchronization_state;
+    output["deterministic_result_hash"] = report.deterministic_result_hash;
+    output["average_propagation_latency_us"] = report.average_propagation_latency_us;
+    output["maximum_propagation_latency_us"] = report.maximum_propagation_latency_us;
+    output["average_measurement_update_latency_us"] = report.average_measurement_update_latency_us;
+    output["maximum_measurement_update_latency_us"] = report.maximum_measurement_update_latency_us;
+    output["success"] = report.success;
+    output["failure_reason"] = report.failure_reason;
+    return output.dump(2);
+}
+
+} // namespace drone::estimation

--- a/src/runtime/RuntimeMode.cpp
+++ b/src/runtime/RuntimeMode.cpp
@@ -172,8 +172,8 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
     if (const auto mode = drone::utils::simple_json::extract_string(content, "mode")) {
         config.estimator_mode = *mode;
     }
-    if (const auto enable = drone::utils::simple_json::extract_bool(content,
-                                                                    "enable_experimental_hybrid")) {
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "enable_experimental_hybrid")) {
         config.estimator_enable_experimental_hybrid = *enable;
     }
     if (const auto enable = drone::utils::simple_json::extract_bool(content, "enable_fej")) {
@@ -182,8 +182,8 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
     if (const auto enable = drone::utils::simple_json::extract_bool(content, "enable_msckf")) {
         config.estimator_enable_msckf = *enable;
     }
-    if (const auto enable = drone::utils::simple_json::extract_bool(
-            content, "enable_loop_closure_correction")) {
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "enable_loop_closure_correction")) {
         config.estimator_enable_loop_closure_correction = *enable;
     }
     if (const auto enable =
@@ -206,8 +206,7 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
             drone::utils::simple_json::extract_number(content, "max_queue_depth")) {
         config.estimator_shadow_max_queue_depth = static_cast<size_t>(*max_depth);
     }
-    if (const auto max_lag =
-            drone::utils::simple_json::extract_number(content, "max_lag_ms")) {
+    if (const auto max_lag = drone::utils::simple_json::extract_number(content, "max_lag_ms")) {
         config.estimator_shadow_max_lag_ms = *max_lag;
     }
     if (const auto threshold =
@@ -227,12 +226,12 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
         config.estimator_shadow_required_consecutive_divergent_samples =
             static_cast<uint32_t>(*samples);
     }
-    if (const auto enable = drone::utils::simple_json::extract_bool(
-            content, "reject_non_finite_measurements")) {
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "reject_non_finite_measurements")) {
         config.estimator_reject_non_finite_measurements = *enable;
     }
-    if (const auto enable = drone::utils::simple_json::extract_bool(
-            content, "require_monotonic_timestamps")) {
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "require_monotonic_timestamps")) {
         config.estimator_require_monotonic_timestamps = *enable;
     }
     if (const auto dt = drone::utils::simple_json::extract_number(content, "max_imu_dt_s")) {
@@ -245,7 +244,8 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
     if (!std::isfinite(config.estimator_max_imu_dt_s) || config.estimator_max_imu_dt_s <= 0.0 ||
         config.estimator_max_imu_dt_s > 0.5) {
         config.estimator_config_valid = false;
-        config.estimator_errors.push_back("estimator.max_imu_dt_s must be finite and within (0, 0.5]");
+        config.estimator_errors.push_back(
+            "estimator.max_imu_dt_s must be finite and within (0, 0.5]");
     }
     if (const auto estimator_mode = lowercase(config.estimator_mode);
         estimator_mode != "minimal" && estimator_mode != "hybrid_active") {
@@ -261,12 +261,12 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
         config.estimator_enable_msckf || config.estimator_enable_loop_closure_correction) {
         config.estimator_config_valid = false;
         config.estimator_errors.push_back(
-            "Phase 15 keeps experimental hybrid/FEJ/MSCKF/loop-closure estimator features disabled");
+            "Phase 15 keeps experimental hybrid/FEJ/MSCKF/loop-closure estimator features "
+            "disabled");
     }
     if (config.estimator_enable_automatic_zupt) {
         config.estimator_config_valid = false;
-        config.estimator_errors.push_back(
-            "automatic ZUPT remains disabled in phase 16");
+        config.estimator_errors.push_back("automatic ZUPT remains disabled in phase 16");
     }
     if (config.estimator_shadow_requested && !config.estimator_shadow_compile_time_supported) {
         config.estimator_config_valid = false;
@@ -282,13 +282,12 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
     if (config.estimator_shadow_max_queue_depth == 0 ||
         config.estimator_shadow_max_queue_depth > 4096) {
         config.estimator_config_valid = false;
-        config.estimator_errors.push_back(
-            "shadow.max_queue_depth must be within [1, 4096]");
+        config.estimator_errors.push_back("shadow.max_queue_depth must be within [1, 4096]");
     }
-    for (const auto value : {config.estimator_shadow_max_lag_ms,
-                             config.estimator_shadow_position_divergence_m,
-                             config.estimator_shadow_velocity_divergence_mps,
-                             config.estimator_shadow_orientation_divergence_deg}) {
+    for (const auto value :
+         {config.estimator_shadow_max_lag_ms, config.estimator_shadow_position_divergence_m,
+          config.estimator_shadow_velocity_divergence_mps,
+          config.estimator_shadow_orientation_divergence_deg}) {
         if (!std::isfinite(value) || value < 0.0) {
             config.estimator_config_valid = false;
             config.estimator_errors.push_back(
@@ -301,9 +300,9 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
         config.estimator_errors.push_back(
             "shadow.required_consecutive_divergent_samples must be positive");
     }
-    config.estimator_shadow_effective =
-        config.estimator_config_valid && config.estimator_shadow_requested &&
-        config.estimator_shadow_compile_time_supported;
+    config.estimator_shadow_effective = config.estimator_config_valid &&
+                                        config.estimator_shadow_requested &&
+                                        config.estimator_shadow_compile_time_supported;
     return config;
 }
 

--- a/src/runtime/RuntimeMode.cpp
+++ b/src/runtime/RuntimeMode.cpp
@@ -168,6 +168,142 @@ RuntimeFileConfig load_runtime_file(const std::string& path) {
             drone::utils::simple_json::extract_string(content, "detector_labels_path")) {
         config.detector_labels_path = *detector_labels_path;
     }
+    config.estimator_config_present = content.find("\"estimator\"") != std::string::npos;
+    if (const auto mode = drone::utils::simple_json::extract_string(content, "mode")) {
+        config.estimator_mode = *mode;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(content,
+                                                                    "enable_experimental_hybrid")) {
+        config.estimator_enable_experimental_hybrid = *enable;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(content, "enable_fej")) {
+        config.estimator_enable_fej = *enable;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(content, "enable_msckf")) {
+        config.estimator_enable_msckf = *enable;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(
+            content, "enable_loop_closure_correction")) {
+        config.estimator_enable_loop_closure_correction = *enable;
+    }
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "enable_automatic_zupt")) {
+        config.estimator_enable_automatic_zupt = *enable;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(content, "enabled")) {
+        config.estimator_shadow_requested = *enable;
+        config.estimator_enable_shadow_estimator = *enable;
+    }
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "comparison_enabled")) {
+        config.estimator_shadow_comparison_enabled = *enable;
+    }
+    if (const auto implementation =
+            drone::utils::simple_json::extract_string(content, "implementation")) {
+        config.estimator_shadow_implementation = *implementation;
+    }
+    if (const auto max_depth =
+            drone::utils::simple_json::extract_number(content, "max_queue_depth")) {
+        config.estimator_shadow_max_queue_depth = static_cast<size_t>(*max_depth);
+    }
+    if (const auto max_lag =
+            drone::utils::simple_json::extract_number(content, "max_lag_ms")) {
+        config.estimator_shadow_max_lag_ms = *max_lag;
+    }
+    if (const auto threshold =
+            drone::utils::simple_json::extract_number(content, "position_divergence_m")) {
+        config.estimator_shadow_position_divergence_m = *threshold;
+    }
+    if (const auto threshold =
+            drone::utils::simple_json::extract_number(content, "velocity_divergence_mps")) {
+        config.estimator_shadow_velocity_divergence_mps = *threshold;
+    }
+    if (const auto threshold =
+            drone::utils::simple_json::extract_number(content, "orientation_divergence_deg")) {
+        config.estimator_shadow_orientation_divergence_deg = *threshold;
+    }
+    if (const auto samples = drone::utils::simple_json::extract_u64(
+            content, "required_consecutive_divergent_samples")) {
+        config.estimator_shadow_required_consecutive_divergent_samples =
+            static_cast<uint32_t>(*samples);
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(
+            content, "reject_non_finite_measurements")) {
+        config.estimator_reject_non_finite_measurements = *enable;
+    }
+    if (const auto enable = drone::utils::simple_json::extract_bool(
+            content, "require_monotonic_timestamps")) {
+        config.estimator_require_monotonic_timestamps = *enable;
+    }
+    if (const auto dt = drone::utils::simple_json::extract_number(content, "max_imu_dt_s")) {
+        config.estimator_max_imu_dt_s = *dt;
+    }
+    if (const auto enable =
+            drone::utils::simple_json::extract_bool(content, "diagnostics_enabled")) {
+        config.estimator_diagnostics_enabled = *enable;
+    }
+    if (!std::isfinite(config.estimator_max_imu_dt_s) || config.estimator_max_imu_dt_s <= 0.0 ||
+        config.estimator_max_imu_dt_s > 0.5) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back("estimator.max_imu_dt_s must be finite and within (0, 0.5]");
+    }
+    if (const auto estimator_mode = lowercase(config.estimator_mode);
+        estimator_mode != "minimal" && estimator_mode != "hybrid_active") {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back("unknown estimator.mode; only \"minimal\" is supported");
+    }
+    if (lowercase(config.estimator_mode) == "hybrid_active") {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "estimator.mode=\"hybrid_active\" is unsupported and rejected in phase 16");
+    }
+    if (config.estimator_enable_experimental_hybrid || config.estimator_enable_fej ||
+        config.estimator_enable_msckf || config.estimator_enable_loop_closure_correction) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "Phase 15 keeps experimental hybrid/FEJ/MSCKF/loop-closure estimator features disabled");
+    }
+    if (config.estimator_enable_automatic_zupt) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "automatic ZUPT remains disabled in phase 16");
+    }
+    if (config.estimator_shadow_requested && !config.estimator_shadow_compile_time_supported) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "shadow estimator requested but compile-time shadow support is disabled");
+    }
+    if (config.estimator_shadow_implementation != "minimal_eskf_clone" &&
+        config.estimator_shadow_implementation != "minimal_shadow_clone") {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "shadow implementation is unsupported; expected minimal_eskf_clone");
+    }
+    if (config.estimator_shadow_max_queue_depth == 0 ||
+        config.estimator_shadow_max_queue_depth > 4096) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "shadow.max_queue_depth must be within [1, 4096]");
+    }
+    for (const auto value : {config.estimator_shadow_max_lag_ms,
+                             config.estimator_shadow_position_divergence_m,
+                             config.estimator_shadow_velocity_divergence_mps,
+                             config.estimator_shadow_orientation_divergence_deg}) {
+        if (!std::isfinite(value) || value < 0.0) {
+            config.estimator_config_valid = false;
+            config.estimator_errors.push_back(
+                "shadow thresholds and lag values must be finite and non-negative");
+            break;
+        }
+    }
+    if (config.estimator_shadow_required_consecutive_divergent_samples == 0) {
+        config.estimator_config_valid = false;
+        config.estimator_errors.push_back(
+            "shadow.required_consecutive_divergent_samples must be positive");
+    }
+    config.estimator_shadow_effective =
+        config.estimator_config_valid && config.estimator_shadow_requested &&
+        config.estimator_shadow_compile_time_supported;
     return config;
 }
 

--- a/src/vio/EKFEstimator.cpp
+++ b/src/vio/EKFEstimator.cpp
@@ -9,11 +9,24 @@
 #include <Eigen/Cholesky>
 #include <Eigen/SVD>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <numeric>
 
 namespace drone::vio {
 
 static constexpr double kGravity = 9.81;
+static constexpr double kCovarianceFloor = 1.0e-12;
+static constexpr double kMaxCorrectionNorm = 100.0;
+
+namespace {
+
+template <typename Derived>
+bool matrix_is_finite(const Eigen::MatrixBase<Derived>& matrix) {
+    return matrix.array().isFinite().all();
+}
+
+} // namespace
 
 EKFEstimator::EKFEstimator(EKFConfig cfg) : cfg_(cfg) {
     logger_ = spdlog::get("EKF");
@@ -26,6 +39,9 @@ EKFEstimator::EKFEstimator(EKFConfig cfg) : cfg_(cfg) {
     Q_imu_.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * cfg_.sigma_ng * cfg_.sigma_ng;
     Q_imu_.block<3, 3>(6, 6) = Eigen::Matrix3d::Identity() * cfg_.sigma_nba * cfg_.sigma_nba;
     Q_imu_.block<3, 3>(9, 9) = Eigen::Matrix3d::Identity() * cfg_.sigma_nbg * cfg_.sigma_nbg;
+    diagnostics_.minimum_covariance_diagonal_seen = kCovarianceFloor;
+    diagnostics_.covariance_min_diagonal = kCovarianceFloor;
+    diagnostics_.health_state = EstimatorHealthState::INITIALIZING;
 }
 
 void EKFEstimator::reset(const Eigen::Vector3d& p0, const Eigen::Quaterniond& q0,
@@ -46,10 +62,14 @@ void EKFEstimator::reset(const Eigen::Vector3d& p0, const Eigen::Quaterniond& q0
     P_.block<3, 3>(12, 12) = Eigen::Matrix3d::Identity() * cfg_.init_bg_std * cfg_.init_bg_std;
 
     timestamp_ = 0.0;
-    total_drift_ = 0.0;
+    estimated_position_uncertainty_m_ = 0.0;
     initialized_ = true;
     last_vision_update_ts_ = -1.0;
     last_depth_update_ts_ = -1.0;
+    diagnostics_ = {};
+    diagnostics_.covariance_min_diagonal = P_.diagonal().minCoeff();
+    diagnostics_.minimum_covariance_diagonal_seen = diagnostics_.covariance_min_diagonal;
+    diagnostics_.health_state = EstimatorHealthState::INITIALIZING;
     logger_->info("EKF reset. p0=[{:.3f},{:.3f},{:.3f}]", p0.x(), p0.y(), p0.z());
 }
 
@@ -57,8 +77,28 @@ void EKFEstimator::reset(const Eigen::Vector3d& p0, const Eigen::Quaterniond& q0
 
 void EKFEstimator::propagate_imu(const Eigen::Vector3d& accel_mps2,
                                  const Eigen::Vector3d& gyro_rads, double dt) {
-    if (!initialized_ || dt <= 0.0 || dt > 0.5)
+    if (!initialized_)
         return;
+    if ((validation_cfg_.reject_non_finite_measurements &&
+         (!matrix_is_finite(accel_mps2) || !matrix_is_finite(gyro_rads) || !std::isfinite(dt)))) {
+        std::lock_guard lock(mtx_);
+        mark_invalid_input("non-finite imu sample rejected");
+        return;
+    }
+    if (dt <= 0.0 ||
+        (validation_cfg_.require_monotonic_timestamps && dt <= 0.0)) {
+        std::lock_guard lock(mtx_);
+        ++diagnostics_.timestamp_rejection_count;
+        mark_measurement_rejected(EstimatorSensorType::IMU, "non-monotonic imu timestamp");
+        return;
+    }
+    if (dt > validation_cfg_.max_imu_dt_s) {
+        std::lock_guard lock(mtx_);
+        ++diagnostics_.timestamp_rejection_count;
+        mark_measurement_rejected(EstimatorSensorType::IMU, "imu dt exceeds configured limit");
+        return;
+    }
+    const auto started_at = std::chrono::steady_clock::now();
     std::lock_guard lock(mtx_);
 
     // Remove bias estimates
@@ -93,10 +133,14 @@ void EKFEstimator::propagate_imu(const Eigen::Vector3d& accel_mps2,
     P_ = F * P_ * F.transpose() + Q_d;
 
     // Symmetrize to prevent numerical drift
-    P_ = 0.5 * (P_ + P_.transpose());
-    total_drift_ = P_.diagonal().head<3>().cwiseSqrt().norm();
+    finalize_covariance_locked();
 
     timestamp_ += dt;
+    ++diagnostics_.propagation_count;
+    accumulate_propagation_latency(
+        std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - started_at)
+            .count());
+    update_health_locked();
 }
 
 // Vision Update  (feature reprojection)
@@ -118,6 +162,12 @@ void EKFEstimator::update_vision(const std::vector<Eigen::Vector2d>& z_pixels,
 
     bool accepted_update = false;
     for (size_t i = 0; i < z_pixels.size(); ++i) {
+        if ((validation_cfg_.reject_non_finite_measurements &&
+             (!matrix_is_finite(z_pixels[i]) || !matrix_is_finite(p_world[i]) ||
+              !matrix_is_finite(K)))) {
+            mark_invalid_input("non-finite vision feature input rejected");
+            return;
+        }
         // Project map point into current camera frame
         const Eigen::Vector3d p_c = R.transpose() * (p_world[i] - pos_);
 
@@ -151,39 +201,10 @@ void EKFEstimator::update_vision(const std::vector<Eigen::Vector2d>& z_pixels,
 
         // Innovation
         const Eigen::Vector2d innov{z_pixels[i].x() - u_hat, z_pixels[i].y() - v_hat};
-
-        // Mahalanobis gating
-        const Eigen::Matrix2d S = H * P_ * H.transpose() + R_meas;
-        const double mah_sq = innov.transpose() * S.ldlt().solve(innov);
-        if (mah_sq > cfg_.mahal_gate)
-            continue; // outlier
-
-        // Kalman gain
-        const Eigen::Matrix<double, 15, 2> K_gain = P_ * H.transpose() * S.inverse();
-
-        // Error state correction
-        const Eigen::Matrix<double, 15, 1> dx = K_gain * innov;
-
-        // Apply correction to nominal state
-        pos_ += dx.segment<3>(0);
-        vel_ += dx.segment<3>(3);
-        ba_ += dx.segment<3>(9);
-        bg_ += dx.segment<3>(12);
-
-        // Quaternion box-plus
-        const Eigen::Vector3d dtheta = dx.segment<3>(6);
-        if (dtheta.norm() > 1e-8) {
-            q_ = q_ * rotvec_to_quat(dtheta);
-            q_.normalize();
+        if (apply_linear_update(H, innov, R_meas, EstimatorSensorType::VISION_FEATURE,
+                                "vision_feature")) {
+            accepted_update = true;
         }
-
-        // Joseph form covariance update (numerically stable)
-        const Eigen::Matrix<double, 15, 15> I_KH =
-            Eigen::Matrix<double, 15, 15>::Identity() - K_gain * H;
-        P_ = I_KH * P_ * I_KH.transpose() + K_gain * R_meas * K_gain.transpose();
-        P_ = 0.5 * (P_ + P_.transpose());
-        total_drift_ = P_.diagonal().head<3>().cwiseSqrt().norm();
-        accepted_update = true;
     }
 
     if (accepted_update) {
@@ -194,23 +215,30 @@ void EKFEstimator::update_vision(const std::vector<Eigen::Vector2d>& z_pixels,
 void EKFEstimator::update_depth(double z_depth_m, double sigma_m) {
     if (!initialized_)
         return;
+    if (validation_cfg_.reject_non_finite_measurements &&
+        (!std::isfinite(z_depth_m) || !std::isfinite(sigma_m))) {
+        std::lock_guard lock(mtx_);
+        mark_invalid_input("non-finite depth measurement rejected");
+        return;
+    }
+    if (!validate_measurement_noise(sigma_m, "depth")) {
+        std::lock_guard lock(mtx_);
+        mark_invalid_input("invalid depth covariance rejected");
+        return;
+    }
     std::lock_guard lock(mtx_);
 
     // H = [0 0 1 | 0...] (z-position only)
     Eigen::Matrix<double, 1, 15> H = Eigen::Matrix<double, 1, 15>::Zero();
     H(0, 2) = 1.0;
 
-    const double innov = z_depth_m - pos_.z();
-    const double S = H * P_ * H.transpose() + sigma_m * sigma_m;
-    const auto K_gain = P_ * H.transpose() / S;
-    const auto dx = K_gain * innov;
-
-    pos_ += dx.segment<3>(0);
-    vel_ += dx.segment<3>(3);
-    P_ -= K_gain * H * P_;
-    P_ = 0.5 * (P_ + P_.transpose());
-    total_drift_ = P_.diagonal().head<3>().cwiseSqrt().norm();
-    last_depth_update_ts_ = timestamp_;
+    const Eigen::Matrix<double, 1, 1> innovation =
+        (Eigen::Matrix<double, 1, 1>() << (z_depth_m - pos_.z())).finished();
+    const Eigen::Matrix<double, 1, 1> R_meas =
+        (Eigen::Matrix<double, 1, 1>() << sigma_m * sigma_m).finished();
+    if (apply_linear_update(H, innovation, R_meas, EstimatorSensorType::DEPTH, "depth")) {
+        last_depth_update_ts_ = timestamp_;
+    }
 }
 
 void EKFEstimator::update_visual_pose(const Eigen::Vector3d& observed_position,
@@ -218,6 +246,19 @@ void EKFEstimator::update_visual_pose(const Eigen::Vector3d& observed_position,
                                       double sigma_position_m, double sigma_velocity_mps) {
     if (!initialized_)
         return;
+    if (validation_cfg_.reject_non_finite_measurements &&
+        (!matrix_is_finite(observed_position) || !matrix_is_finite(observed_velocity) ||
+         !std::isfinite(sigma_position_m) || !std::isfinite(sigma_velocity_mps))) {
+        std::lock_guard lock(mtx_);
+        mark_invalid_input("non-finite visual pose input rejected");
+        return;
+    }
+    if (!validate_measurement_noise(sigma_position_m, "visual_pose_position") ||
+        !validate_measurement_noise(sigma_velocity_mps, "visual_pose_velocity")) {
+        std::lock_guard lock(mtx_);
+        mark_invalid_input("invalid visual pose covariance rejected");
+        return;
+    }
     std::lock_guard lock(mtx_);
 
     Eigen::Matrix<double, 6, 15> H = Eigen::Matrix<double, 6, 15>::Zero();
@@ -232,22 +273,9 @@ void EKFEstimator::update_visual_pose(const Eigen::Vector3d& observed_position,
     Eigen::Matrix<double, 6, 1> innov;
     innov.segment<3>(0) = observed_position - pos_;
     innov.segment<3>(3) = observed_velocity - vel_;
-
-    const Eigen::Matrix<double, 6, 6> S = H * P_ * H.transpose() + R_meas;
-    const Eigen::Matrix<double, 15, 6> K_gain = P_ * H.transpose() * S.inverse();
-    const auto dx = K_gain * innov;
-
-    pos_ += dx.segment<3>(0);
-    vel_ += dx.segment<3>(3);
-    ba_ += dx.segment<3>(9);
-    bg_ += dx.segment<3>(12);
-
-    const Eigen::Matrix<double, 15, 15> I_KH =
-        Eigen::Matrix<double, 15, 15>::Identity() - K_gain * H;
-    P_ = I_KH * P_ * I_KH.transpose() + K_gain * R_meas * K_gain.transpose();
-    P_ = 0.5 * (P_ + P_.transpose());
-    total_drift_ = P_.diagonal().head<3>().cwiseSqrt().norm();
-    last_vision_update_ts_ = timestamp_;
+    if (apply_linear_update(H, innov, R_meas, EstimatorSensorType::VISUAL_POSE, "visual_pose")) {
+        last_vision_update_ts_ = timestamp_;
+    }
 }
 
 void EKFEstimator::update_zupt() {
@@ -259,18 +287,10 @@ void EKFEstimator::update_zupt() {
     Eigen::Matrix<double, 3, 15> H = Eigen::Matrix<double, 3, 15>::Zero();
     H.block<3, 3>(0, 3) = Eigen::Matrix3d::Identity();
 
-    const Eigen::Matrix3d R_meas = Eigen::Matrix3d::Identity() * 1e-4;
+    const Eigen::Matrix3d R_meas = Eigen::Matrix3d::Identity() * 1e-6;
     const Eigen::Vector3d innov = -vel_;
-
-    const Eigen::Matrix3d S = H * P_ * H.transpose() + R_meas;
-    const Eigen::Matrix<double, 15, 3> K_gain = P_ * H.transpose() * S.inverse();
-    const auto dx = K_gain * innov;
-
-    vel_ += dx.segment<3>(3);
-    vel_.setZero();
-    P_ -= K_gain * H * P_;
-    P_ = 0.5 * (P_ + P_.transpose());
-    total_drift_ = P_.diagonal().head<3>().cwiseSqrt().norm();
+    apply_linear_update(H, innov, R_meas, EstimatorSensorType::ZUPT, "zupt",
+                        true, true, true, false);
 }
 
 PoseEstimate EKFEstimator::state() const {
@@ -282,8 +302,8 @@ PoseEstimate EKFEstimator::state() const {
     est.orientation = q_;
     est.accel_bias = ba_;
     est.gyro_bias = bg_;
-    est.pos_std = P_.diagonal().head<3>().cwiseSqrt();
-    est.drift_m = total_drift_;
+    est.pos_std = P_.diagonal().head<3>().cwiseMax(kCovarianceFloor).cwiseSqrt();
+    est.drift_m = estimated_position_uncertainty_m_;
 
     const double uncertainty_norm = est.pos_std.norm();
     const double vision_age = (last_vision_update_ts_ >= 0.0)
@@ -319,6 +339,30 @@ PoseEstimate EKFEstimator::state() const {
         est.localization_source = "imu-dead-reckoning";
     }
     return est;
+}
+
+EstimatorDiagnostics EKFEstimator::diagnostics() const {
+    std::lock_guard lock(mtx_);
+    return diagnostics_;
+}
+
+void EKFEstimator::set_validation_config(EstimatorValidationConfig config) {
+    std::lock_guard lock(mtx_);
+    validation_cfg_ = std::move(config);
+    update_health_locked();
+}
+
+void EKFEstimator::note_timestamp_violation(const std::string& reason) {
+    std::lock_guard lock(mtx_);
+    ++diagnostics_.timestamp_rejection_count;
+    mark_measurement_rejected(EstimatorSensorType::IMU, reason);
+}
+
+void EKFEstimator::note_dropped_sensor_event(const std::string& reason) {
+    std::lock_guard lock(mtx_);
+    ++diagnostics_.dropped_sensor_event_count;
+    diagnostics_.last_rejection_reason = reason;
+    update_health_locked();
 }
 
 // Private helpers
@@ -372,6 +416,193 @@ Eigen::Quaterniond EKFEstimator::rotvec_to_quat(const Eigen::Vector3d& rv) {
 Eigen::Vector3d EKFEstimator::quat_to_rotvec(const Eigen::Quaterniond& q) {
     const Eigen::AngleAxisd aa(q);
     return aa.axis() * aa.angle();
+}
+
+template <int N>
+bool EKFEstimator::apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
+                                       const Eigen::Matrix<double, N, 1>& innovation,
+                                       const Eigen::Matrix<double, N, N>& R_meas,
+                                       EstimatorSensorType sensor_type, const char* sensor_name,
+                                       bool apply_velocity, bool apply_biases,
+                                       bool apply_attitude, bool enable_gating) {
+    const auto started_at = std::chrono::steady_clock::now();
+    if (!matrix_is_finite(H) || !matrix_is_finite(innovation) || !matrix_is_finite(R_meas)) {
+        mark_invalid_input(std::string(sensor_name) + " update had non-finite matrices");
+        return false;
+    }
+
+    const Eigen::Matrix<double, N, N> S = H * P_ * H.transpose() + R_meas;
+    if (!matrix_is_finite(S)) {
+        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " innovation covariance invalid");
+        return false;
+    }
+    Eigen::LDLT<Eigen::Matrix<double, N, N>> ldlt(S);
+    if (ldlt.info() != Eigen::Success) {
+        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " innovation solve failed");
+        return false;
+    }
+
+    const double innovation_magnitude = innovation.norm();
+    const double mahal_sq = innovation.dot(ldlt.solve(innovation));
+    if (!std::isfinite(mahal_sq)) {
+        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " mahalanobis invalid");
+        return false;
+    }
+    if (enable_gating && mahal_sq > cfg_.mahal_gate) {
+        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " innovation gated");
+        diagnostics_.last_innovation_magnitude = innovation_magnitude;
+        diagnostics_.last_mahalanobis_distance = std::sqrt(std::max(0.0, mahal_sq));
+        return false;
+    }
+
+    const Eigen::Matrix<double, 15, N> K_gain =
+        ldlt.solve(H * P_.transpose()).transpose();
+    const Eigen::Matrix<double, 15, 1> dx = K_gain * innovation;
+    if (!matrix_is_finite(dx) || dx.norm() > kMaxCorrectionNorm) {
+        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " correction invalid");
+        return false;
+    }
+
+    pos_ += dx.segment<3>(0);
+    if (apply_velocity) {
+        vel_ += dx.segment<3>(3);
+    }
+    if (apply_biases) {
+        ba_ += dx.segment<3>(9);
+        bg_ += dx.segment<3>(12);
+    }
+    if (apply_attitude) {
+        const Eigen::Vector3d dtheta = dx.segment<3>(6);
+        if (dtheta.norm() > 1e-8) {
+            q_ = q_ * rotvec_to_quat(dtheta);
+            q_.normalize();
+        }
+    }
+
+    const Eigen::Matrix<double, 15, 15> I_KH =
+        Eigen::Matrix<double, 15, 15>::Identity() - K_gain * H;
+    P_ = I_KH * P_ * I_KH.transpose() + K_gain * R_meas * K_gain.transpose();
+    finalize_covariance_locked();
+
+    mark_measurement_accepted(sensor_type, innovation_magnitude, std::sqrt(std::max(0.0, mahal_sq)));
+    accumulate_measurement_latency(
+        std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - started_at)
+            .count());
+    update_health_locked();
+    return true;
+}
+
+bool EKFEstimator::validate_measurement_noise(double sigma_m, const char* sensor_name) {
+    if (!std::isfinite(sigma_m) || sigma_m <= 0.0) {
+        if (logger_) {
+            logger_->warn("{} measurement rejected due to invalid sigma {}", sensor_name, sigma_m);
+        }
+        return false;
+    }
+    return true;
+}
+
+bool EKFEstimator::validate_state_finite() const {
+    return matrix_is_finite(pos_) && matrix_is_finite(vel_) && matrix_is_finite(ba_) &&
+           matrix_is_finite(bg_) && std::isfinite(q_.w()) && std::isfinite(q_.x()) &&
+           std::isfinite(q_.y()) && std::isfinite(q_.z());
+}
+
+bool EKFEstimator::validate_covariance_finite() const {
+    return matrix_is_finite(P_);
+}
+
+void EKFEstimator::finalize_covariance_locked() {
+    P_ = 0.5 * (P_ + P_.transpose());
+    for (int i = 0; i < P_.rows(); ++i) {
+        if (!std::isfinite(P_(i, i)) || P_(i, i) < kCovarianceFloor) {
+            P_(i, i) = kCovarianceFloor;
+        }
+    }
+    diagnostics_.covariance_symmetry_error = (P_ - P_.transpose()).cwiseAbs().maxCoeff();
+    diagnostics_.max_covariance_asymmetry =
+        std::max(diagnostics_.max_covariance_asymmetry, diagnostics_.covariance_symmetry_error);
+    diagnostics_.covariance_min_diagonal = P_.diagonal().minCoeff();
+    diagnostics_.minimum_covariance_diagonal_seen =
+        diagnostics_.propagation_count == 0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISION_FEATURE)] == 0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISUAL_POSE)] == 0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::DEPTH)] == 0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::ZUPT)] == 0
+            ? diagnostics_.covariance_min_diagonal
+            : std::min(diagnostics_.minimum_covariance_diagonal_seen,
+                       diagnostics_.covariance_min_diagonal);
+    estimated_position_uncertainty_m_ =
+        P_.diagonal().head<3>().cwiseMax(kCovarianceFloor).cwiseSqrt().norm();
+    diagnostics_.has_non_finite_covariance = !validate_covariance_finite();
+    diagnostics_.has_non_finite_state = !validate_state_finite();
+}
+
+void EKFEstimator::mark_measurement_rejected(EstimatorSensorType sensor_type, std::string reason) {
+    ++diagnostics_.rejected_updates[sensor_index(sensor_type)];
+    diagnostics_.last_rejection_reason = std::move(reason);
+    update_health_locked();
+}
+
+void EKFEstimator::mark_measurement_accepted(EstimatorSensorType sensor_type,
+                                             double innovation_magnitude,
+                                             double mahalanobis_distance) {
+    ++diagnostics_.accepted_updates[sensor_index(sensor_type)];
+    diagnostics_.last_innovation_magnitude = innovation_magnitude;
+    diagnostics_.last_mahalanobis_distance = mahalanobis_distance;
+    diagnostics_.last_rejection_reason = "none";
+}
+
+void EKFEstimator::mark_invalid_input(std::string reason) {
+    ++diagnostics_.invalid_input_count;
+    diagnostics_.last_rejection_reason = std::move(reason);
+    update_health_locked();
+}
+
+void EKFEstimator::update_health_locked() {
+    diagnostics_.has_non_finite_state = !validate_state_finite();
+    diagnostics_.has_non_finite_covariance = !validate_covariance_finite();
+    if (diagnostics_.has_non_finite_state || diagnostics_.has_non_finite_covariance) {
+        diagnostics_.health_state = EstimatorHealthState::INVALID;
+        return;
+    }
+    if (!initialized_) {
+        diagnostics_.health_state = EstimatorHealthState::INITIALIZING;
+        return;
+    }
+    if (diagnostics_.covariance_min_diagonal <= kCovarianceFloor ||
+        diagnostics_.covariance_symmetry_error > 1.0e-6) {
+        diagnostics_.health_state = EstimatorHealthState::NUMERICAL_WARNING;
+        return;
+    }
+    const uint64_t rejected_total = std::accumulate(diagnostics_.rejected_updates.begin(),
+                                                    diagnostics_.rejected_updates.end(), uint64_t{0});
+    if (rejected_total > 0 && diagnostics_.propagation_count == 0) {
+        diagnostics_.health_state = EstimatorHealthState::REJECTING_MEASUREMENTS;
+        return;
+    }
+    if (estimated_position_uncertainty_m_ > 1.8 || diagnostics_.invalid_input_count > 0) {
+        diagnostics_.health_state = EstimatorHealthState::DEGRADED;
+        return;
+    }
+    diagnostics_.health_state = EstimatorHealthState::NOMINAL;
+}
+
+void EKFEstimator::accumulate_propagation_latency(double latency_us) {
+    diagnostics_.max_update_latency_us = std::max(diagnostics_.max_update_latency_us, latency_us);
+    const double count = static_cast<double>(std::max<uint64_t>(1, diagnostics_.propagation_count));
+    diagnostics_.average_propagation_latency_us =
+        ((diagnostics_.average_propagation_latency_us * (count - 1.0)) + latency_us) / count;
+}
+
+void EKFEstimator::accumulate_measurement_latency(double latency_us) {
+    diagnostics_.max_update_latency_us = std::max(diagnostics_.max_update_latency_us, latency_us);
+    const uint64_t accepted_total =
+        std::accumulate(diagnostics_.accepted_updates.begin(), diagnostics_.accepted_updates.end(),
+                        uint64_t{0});
+    const double count = static_cast<double>(std::max<uint64_t>(1, accepted_total));
+    diagnostics_.average_measurement_latency_us =
+        ((diagnostics_.average_measurement_latency_us * (count - 1.0)) + latency_us) / count;
 }
 
 } // namespace drone::vio

--- a/src/vio/EKFEstimator.cpp
+++ b/src/vio/EKFEstimator.cpp
@@ -21,8 +21,7 @@ static constexpr double kMaxCorrectionNorm = 100.0;
 
 namespace {
 
-template <typename Derived>
-bool matrix_is_finite(const Eigen::MatrixBase<Derived>& matrix) {
+template <typename Derived> bool matrix_is_finite(const Eigen::MatrixBase<Derived>& matrix) {
     return matrix.array().isFinite().all();
 }
 
@@ -85,8 +84,7 @@ void EKFEstimator::propagate_imu(const Eigen::Vector3d& accel_mps2,
         mark_invalid_input("non-finite imu sample rejected");
         return;
     }
-    if (dt <= 0.0 ||
-        (validation_cfg_.require_monotonic_timestamps && dt <= 0.0)) {
+    if (dt <= 0.0 || (validation_cfg_.require_monotonic_timestamps && dt <= 0.0)) {
         std::lock_guard lock(mtx_);
         ++diagnostics_.timestamp_rejection_count;
         mark_measurement_rejected(EstimatorSensorType::IMU, "non-monotonic imu timestamp");
@@ -289,8 +287,8 @@ void EKFEstimator::update_zupt() {
 
     const Eigen::Matrix3d R_meas = Eigen::Matrix3d::Identity() * 1e-6;
     const Eigen::Vector3d innov = -vel_;
-    apply_linear_update(H, innov, R_meas, EstimatorSensorType::ZUPT, "zupt",
-                        true, true, true, false);
+    apply_linear_update(H, innov, R_meas, EstimatorSensorType::ZUPT, "zupt", true, true, true,
+                        false);
 }
 
 PoseEstimate EKFEstimator::state() const {
@@ -423,8 +421,8 @@ bool EKFEstimator::apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
                                        const Eigen::Matrix<double, N, 1>& innovation,
                                        const Eigen::Matrix<double, N, N>& R_meas,
                                        EstimatorSensorType sensor_type, const char* sensor_name,
-                                       bool apply_velocity, bool apply_biases,
-                                       bool apply_attitude, bool enable_gating) {
+                                       bool apply_velocity, bool apply_biases, bool apply_attitude,
+                                       bool enable_gating) {
     const auto started_at = std::chrono::steady_clock::now();
     if (!matrix_is_finite(H) || !matrix_is_finite(innovation) || !matrix_is_finite(R_meas)) {
         mark_invalid_input(std::string(sensor_name) + " update had non-finite matrices");
@@ -433,12 +431,14 @@ bool EKFEstimator::apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
 
     const Eigen::Matrix<double, N, N> S = H * P_ * H.transpose() + R_meas;
     if (!matrix_is_finite(S)) {
-        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " innovation covariance invalid");
+        mark_measurement_rejected(sensor_type,
+                                  std::string(sensor_name) + " innovation covariance invalid");
         return false;
     }
     Eigen::LDLT<Eigen::Matrix<double, N, N>> ldlt(S);
     if (ldlt.info() != Eigen::Success) {
-        mark_measurement_rejected(sensor_type, std::string(sensor_name) + " innovation solve failed");
+        mark_measurement_rejected(sensor_type,
+                                  std::string(sensor_name) + " innovation solve failed");
         return false;
     }
 
@@ -455,8 +455,7 @@ bool EKFEstimator::apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
         return false;
     }
 
-    const Eigen::Matrix<double, 15, N> K_gain =
-        ldlt.solve(H * P_.transpose()).transpose();
+    const Eigen::Matrix<double, 15, N> K_gain = ldlt.solve(H * P_.transpose()).transpose();
     const Eigen::Matrix<double, 15, 1> dx = K_gain * innovation;
     if (!matrix_is_finite(dx) || dx.norm() > kMaxCorrectionNorm) {
         mark_measurement_rejected(sensor_type, std::string(sensor_name) + " correction invalid");
@@ -484,7 +483,8 @@ bool EKFEstimator::apply_linear_update(const Eigen::Matrix<double, N, 15>& H,
     P_ = I_KH * P_ * I_KH.transpose() + K_gain * R_meas * K_gain.transpose();
     finalize_covariance_locked();
 
-    mark_measurement_accepted(sensor_type, innovation_magnitude, std::sqrt(std::max(0.0, mahal_sq)));
+    mark_measurement_accepted(sensor_type, innovation_magnitude,
+                              std::sqrt(std::max(0.0, mahal_sq)));
     accumulate_measurement_latency(
         std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - started_at)
             .count());
@@ -525,8 +525,10 @@ void EKFEstimator::finalize_covariance_locked() {
     diagnostics_.covariance_min_diagonal = P_.diagonal().minCoeff();
     diagnostics_.minimum_covariance_diagonal_seen =
         diagnostics_.propagation_count == 0 &&
-                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISION_FEATURE)] == 0 &&
-                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISUAL_POSE)] == 0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISION_FEATURE)] ==
+                    0 &&
+                diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::VISUAL_POSE)] ==
+                    0 &&
                 diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::DEPTH)] == 0 &&
                 diagnostics_.accepted_updates[sensor_index(EstimatorSensorType::ZUPT)] == 0
             ? diagnostics_.covariance_min_diagonal
@@ -575,8 +577,8 @@ void EKFEstimator::update_health_locked() {
         diagnostics_.health_state = EstimatorHealthState::NUMERICAL_WARNING;
         return;
     }
-    const uint64_t rejected_total = std::accumulate(diagnostics_.rejected_updates.begin(),
-                                                    diagnostics_.rejected_updates.end(), uint64_t{0});
+    const uint64_t rejected_total = std::accumulate(
+        diagnostics_.rejected_updates.begin(), diagnostics_.rejected_updates.end(), uint64_t{0});
     if (rejected_total > 0 && diagnostics_.propagation_count == 0) {
         diagnostics_.health_state = EstimatorHealthState::REJECTING_MEASUREMENTS;
         return;
@@ -597,9 +599,8 @@ void EKFEstimator::accumulate_propagation_latency(double latency_us) {
 
 void EKFEstimator::accumulate_measurement_latency(double latency_us) {
     diagnostics_.max_update_latency_us = std::max(diagnostics_.max_update_latency_us, latency_us);
-    const uint64_t accepted_total =
-        std::accumulate(diagnostics_.accepted_updates.begin(), diagnostics_.accepted_updates.end(),
-                        uint64_t{0});
+    const uint64_t accepted_total = std::accumulate(
+        diagnostics_.accepted_updates.begin(), diagnostics_.accepted_updates.end(), uint64_t{0});
     const double count = static_cast<double>(std::max<uint64_t>(1, accepted_total));
     diagnostics_.average_measurement_latency_us =
         ((diagnostics_.average_measurement_latency_us * (count - 1.0)) + latency_us) / count;

--- a/src/vio/VIOPipeline.cpp
+++ b/src/vio/VIOPipeline.cpp
@@ -369,7 +369,8 @@ void VIOPipeline::processing_loop() {
 }
 
 void VIOPipeline::handle(const sensors::ImuMeasurement& imu) {
-    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING &&
+    if (coordinator_.active_snapshot().diagnostics.health_state ==
+            EstimatorHealthState::INITIALIZING &&
         last_imu_ts_ < 0.0) {
         coordinator_.reset({});
         last_imu_ts_ = imu.timestamp;
@@ -398,7 +399,8 @@ void VIOPipeline::handle(const sensors::ImuMeasurement& imu) {
 }
 
 void VIOPipeline::handle(const sensors::CameraFrame& frame) {
-    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING)
+    if (coordinator_.active_snapshot().diagnostics.health_state ==
+        EstimatorHealthState::INITIALIZING)
         return;
     if (frame.detections.empty() && frame.image.empty())
         return;
@@ -471,7 +473,8 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
 }
 
 void VIOPipeline::handle(const sensors::LidarMeasurement& lidar) {
-    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING ||
+    if (coordinator_.active_snapshot().diagnostics.health_state ==
+            EstimatorHealthState::INITIALIZING ||
         !lidar.cloud)
         return;
 
@@ -536,7 +539,8 @@ void VIOPipeline::update_shadow_runtime_telemetry() {
         runtime_telemetry_.shadow_estimator_name = telemetry.shadow_estimator_name;
         runtime_telemetry_.active_estimator_health =
             estimator_health_to_string(telemetry.active_health);
-        runtime_telemetry_.shadow_estimator_health = shadow_health_to_string(telemetry.shadow_health);
+        runtime_telemetry_.shadow_estimator_health =
+            shadow_health_to_string(telemetry.shadow_health);
         runtime_telemetry_.shadow_enabled = telemetry.enabled;
         runtime_telemetry_.shadow_lag_ms = telemetry.lag_ms;
         runtime_telemetry_.shadow_queue_depth = telemetry.queue_depth;

--- a/src/vio/VIOPipeline.cpp
+++ b/src/vio/VIOPipeline.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cmath>
 #include <mutex>
+#include <memory>
 #include <numeric>
 
 namespace drone::vio {
@@ -72,6 +73,12 @@ double mean_optical_flow_error(const std::vector<float>& errors, const std::vect
 }
 
 } // namespace
+
+VIOPipeline::VIOPipeline(EKFConfig cfg)
+    : ekf_config_(cfg), active_estimator_(std::make_shared<estimation::MinimalEskfAdapter>(cfg)),
+      coordinator_(std::static_pointer_cast<estimation::StateEstimator>(active_estimator_)) {
+    active_estimator_->set_validation_config(estimator_validation_config_);
+}
 
 bool visual_placeholder_allowed(drone::runtime::RuntimeMode mode) {
     return mode == drone::runtime::RuntimeMode::SIMULATION;
@@ -266,7 +273,27 @@ bool VIOPipeline::start() {
     if (running_.exchange(true))
         return true;
 
-    ekf_.reset();
+    coordinator_.reset({});
+    if (estimator_validation_config_.enable_shadow_estimator) {
+        estimation::ShadowEstimatorConfig shadow_config;
+        shadow_config.enabled = true;
+        shadow_config.comparison_enabled = estimator_validation_config_.shadow_comparison_enabled;
+        shadow_config.max_queue_depth = estimator_validation_config_.shadow_max_queue_depth;
+        shadow_config.max_lag_ms = estimator_validation_config_.shadow_max_lag_ms;
+        shadow_config.thresholds.position_divergence_m =
+            estimator_validation_config_.shadow_position_divergence_m;
+        shadow_config.thresholds.velocity_divergence_mps =
+            estimator_validation_config_.shadow_velocity_divergence_mps;
+        shadow_config.thresholds.orientation_divergence_deg =
+            estimator_validation_config_.shadow_orientation_divergence_deg;
+        shadow_config.thresholds.required_consecutive_divergent_samples =
+            estimator_validation_config_.shadow_required_consecutive_divergent_samples;
+        auto shadow = std::make_unique<estimation::MinimalEskfAdapter>(ekf_config_);
+        shadow->set_validation_config(estimator_validation_config_);
+        coordinator_.configure_shadow(std::move(shadow_config), std::move(shadow));
+    } else {
+        coordinator_.stop_shadow();
+    }
 
     proc_thread_ = std::thread([this] { processing_loop(); });
 
@@ -281,6 +308,7 @@ void VIOPipeline::stop() {
     queue_cv_.notify_all();
     if (proc_thread_.joinable())
         proc_thread_.join();
+    coordinator_.stop_shadow();
     if (logger_)
         logger_->info("VIO pipeline stopped");
 }
@@ -289,9 +317,10 @@ void VIOPipeline::reset() {
     std::lock_guard lock(queue_mutex_);
     while (!event_queue_.empty())
         event_queue_.pop();
-    ekf_.reset();
+    coordinator_.reset({});
     last_imu_ts_ = -1.0;
     last_camera_ts_ = -1.0;
+    measurement_sequence_ = 0;
     previous_gray_frame_.release();
     previous_camera_pose_valid_ = false;
     {
@@ -301,7 +330,7 @@ void VIOPipeline::reset() {
 }
 
 PoseEstimate VIOPipeline::current_pose() const {
-    auto pose = ekf_.state();
+    auto pose = coordinator_.active_snapshot().pose;
     apply_visual_quality_to_pose(pose);
     return pose;
 }
@@ -340,28 +369,41 @@ void VIOPipeline::processing_loop() {
 }
 
 void VIOPipeline::handle(const sensors::ImuMeasurement& imu) {
-    if (!ekf_.is_initialized()) {
-        ekf_.reset();
+    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING &&
+        last_imu_ts_ < 0.0) {
+        coordinator_.reset({});
         last_imu_ts_ = imu.timestamp;
         return;
     }
 
-    const double dt = (last_imu_ts_ > 0.0) ? (imu.timestamp - last_imu_ts_) : 0.0025;
-
-    last_imu_ts_ = imu.timestamp;
-
-    if (dt > 0.0 && dt < 0.1) {
-        ekf_.propagate_imu(imu.accel_mps2, imu.gyro_rads, dt);
+    if (!imu.accel_mps2.array().isFinite().all() || !imu.gyro_rads.array().isFinite().all() ||
+        !std::isfinite(imu.timestamp)) {
+        return;
     }
+
+    const double dt = (last_imu_ts_ > 0.0) ? (imu.timestamp - last_imu_ts_) : 0.0025;
+    if (last_imu_ts_ > 0.0 && dt <= 0.0) {
+        return;
+    }
+    if (dt >= 0.1) {
+        last_imu_ts_ = imu.timestamp;
+        return;
+    }
+    last_imu_ts_ = imu.timestamp;
+    const auto adapted = estimation::MeasurementAdapters::adapt_imu(imu, ++measurement_sequence_);
+    if (adapted.measurement.has_value()) {
+        static_cast<void>(coordinator_.process(*adapted.measurement));
+    }
+    update_shadow_runtime_telemetry();
 }
 
 void VIOPipeline::handle(const sensors::CameraFrame& frame) {
-    if (!ekf_.is_initialized())
+    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING)
         return;
     if (frame.detections.empty() && frame.image.empty())
         return;
 
-    const auto predicted_pose = ekf_.state();
+    const auto predicted_pose = coordinator_.active_snapshot().pose;
     VisualFrontendResult frontend_result;
     cv::Mat current_gray = to_gray(frame.image);
     const double dt = (last_camera_ts_ > 0.0) ? (frame.timestamp - last_camera_ts_) : 0.0;
@@ -375,13 +417,13 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
     }
 
     if (frontend_result.metrics.update_accepted) {
-        const double sigma_position_m = std::clamp(
-            0.50 - (frontend_result.metrics.visual_update_confidence * 0.28), 0.14, 0.50);
-        const double sigma_velocity_mps = std::clamp(
-            0.65 - (frontend_result.metrics.visual_update_confidence * 0.30), 0.18, 0.65);
-        ekf_.update_visual_pose(frontend_result.observed_position,
-                                frontend_result.observed_velocity, sigma_position_m,
-                                sigma_velocity_mps);
+        const auto adapted = estimation::MeasurementAdapters::adapt_visual_pose(
+            frame.timestamp, frontend_result.observed_position, frontend_result.observed_velocity,
+            frontend_result.relative_orientation, frontend_result.metrics.visual_update_confidence,
+            frontend_result.metrics.update_accepted, ++measurement_sequence_, false);
+        if (adapted.measurement.has_value()) {
+            static_cast<void>(coordinator_.process(*adapted.measurement));
+        }
     } else if (visual_placeholder_allowed(runtime_mode_) && !frame.detections.empty()) {
         const auto placeholder =
             build_placeholder_visual_frontend_result(frame, predicted_pose, K_);
@@ -402,7 +444,7 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
             p_world.push_back(predicted_pose.position + forward * 5.0);
         }
         if (!z_pixels.empty()) {
-            ekf_.update_vision(z_pixels, p_world, K_);
+            active_estimator_->estimator().update_vision(z_pixels, p_world, K_);
         }
     }
 
@@ -422,13 +464,15 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
     }
 
     previous_gray_frame_ = current_gray;
-    previous_camera_pose_ = ekf_.state();
+    previous_camera_pose_ = coordinator_.active_snapshot().pose;
     previous_camera_pose_valid_ = true;
     last_camera_ts_ = frame.timestamp;
+    update_shadow_runtime_telemetry();
 }
 
 void VIOPipeline::handle(const sensors::LidarMeasurement& lidar) {
-    if (!ekf_.is_initialized() || !lidar.cloud)
+    if (coordinator_.active_snapshot().diagnostics.health_state == EstimatorHealthState::INITIALIZING ||
+        !lidar.cloud)
         return;
 
     if (lidar.cloud->empty())
@@ -446,10 +490,15 @@ void VIOPipeline::handle(const sensors::LidarMeasurement& lidar) {
     std::nth_element(z_vals.begin(), z_vals.begin() + z_vals.size() / 2, z_vals.end());
     const double ground_z = z_vals[z_vals.size() / 2];
 
-    const auto pose = ekf_.state();
+    const auto pose = coordinator_.active_snapshot().pose;
     const double height = pose.position.z() - ground_z;
-    if (height > 0.3 && height < 100.0)
-        ekf_.update_depth(pose.position.z(), 0.05);
+    if (!std::isfinite(height) || height <= 0.3 || height >= 100.0) {
+        return;
+    }
+    // Phase 15 safety baseline: this plane fit only provides a local sensor-frame ground-relative
+    // height. Without explicit frame calibration and observability to world-frame altitude, it is
+    // unsafe to feed it into the active EKF depth update.
+    update_shadow_runtime_telemetry();
 }
 
 void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
@@ -477,6 +526,69 @@ void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
     if (pose.localization_confidence < 0.22) {
         pose.localization_lost = true;
     }
+}
+
+void VIOPipeline::update_shadow_runtime_telemetry() {
+    const auto telemetry = coordinator_.telemetry();
+    {
+        std::lock_guard lock(runtime_mutex_);
+        runtime_telemetry_.active_estimator_name = telemetry.active_estimator_name;
+        runtime_telemetry_.shadow_estimator_name = telemetry.shadow_estimator_name;
+        runtime_telemetry_.active_estimator_health =
+            estimator_health_to_string(telemetry.active_health);
+        runtime_telemetry_.shadow_estimator_health = shadow_health_to_string(telemetry.shadow_health);
+        runtime_telemetry_.shadow_enabled = telemetry.enabled;
+        runtime_telemetry_.shadow_lag_ms = telemetry.lag_ms;
+        runtime_telemetry_.shadow_queue_depth = telemetry.queue_depth;
+        runtime_telemetry_.shadow_queue_high_water_mark = telemetry.queue_high_water_mark;
+        runtime_telemetry_.shadow_dropped_events = telemetry.dropped_events;
+        runtime_telemetry_.shadow_position_delta_m = telemetry.position_delta_m;
+        runtime_telemetry_.shadow_velocity_delta_mps = telemetry.velocity_delta_mps;
+        runtime_telemetry_.shadow_orientation_delta_deg = telemetry.orientation_delta_deg;
+        runtime_telemetry_.shadow_divergence_active = telemetry.divergence_active;
+        runtime_telemetry_.shadow_last_failure_reason = telemetry.last_failure_reason;
+        runtime_telemetry_.shadow_comparable_snapshot_count = telemetry.comparable_snapshot_count;
+    }
+}
+
+std::string VIOPipeline::estimator_health_to_string(EstimatorHealthState state) {
+    switch (state) {
+    case EstimatorHealthState::INITIALIZING:
+        return "initializing";
+    case EstimatorHealthState::NOMINAL:
+        return "nominal";
+    case EstimatorHealthState::DEGRADED:
+        return "degraded";
+    case EstimatorHealthState::REJECTING_MEASUREMENTS:
+        return "rejecting_measurements";
+    case EstimatorHealthState::NUMERICAL_WARNING:
+        return "numerical_warning";
+    case EstimatorHealthState::INVALID:
+        return "invalid";
+    }
+    return "unknown";
+}
+
+std::string VIOPipeline::shadow_health_to_string(estimation::ShadowHealthState state) {
+    switch (state) {
+    case estimation::ShadowHealthState::DISABLED:
+        return "disabled";
+    case estimation::ShadowHealthState::STARTING:
+        return "starting";
+    case estimation::ShadowHealthState::SYNCHRONIZED:
+        return "synchronized";
+    case estimation::ShadowHealthState::LAGGING:
+        return "lagging";
+    case estimation::ShadowHealthState::STALE:
+        return "stale";
+    case estimation::ShadowHealthState::DIVERGED:
+        return "diverged";
+    case estimation::ShadowHealthState::FAILED:
+        return "failed";
+    case estimation::ShadowHealthState::STOPPED:
+        return "stopped";
+    }
+    return "unknown";
 }
 
 } // namespace drone::vio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,10 @@ add_executable(test_navigation_intelligence
     ../src/localization/TDOAIngestor.cpp
     ../src/localization/TDOALocalizer.cpp
     ../src/localization/TimeSyncTracker.cpp
+    ../src/estimation/EstimatorComparison.cpp
+    ../src/estimation/EstimatorCoordinator.cpp
+    ../src/estimation/MeasurementAdapters.cpp
+    ../src/estimation/MinimalEskfAdapter.cpp
     ../src/runtime/RuntimeMode.cpp
     ../src/safety/SafetyManager.cpp
     ../src/security/PeerPacketAuth.cpp
@@ -113,6 +117,25 @@ target_link_libraries(test_navigation_intelligence PRIVATE
 )
 target_compile_definitions(test_navigation_intelligence PRIVATE ${DRONE_PCL_COMPILE_DEFINITIONS})
 drone_register_gtest(test_navigation_intelligence "unit;navigation;sensor;swarm;telemetry;security;simulation")
+
+add_executable(test_estimator_shadow test_estimator_shadow.cpp)
+target_link_libraries(test_estimator_shadow PRIVATE
+    drone_test_support
+    estimator_validation_core
+    Eigen3::Eigen
+)
+drone_register_gtest(test_estimator_shadow "unit;navigation;estimation")
+
+add_executable(test_estimator_replay test_estimator_replay.cpp)
+target_link_libraries(test_estimator_replay PRIVATE
+    drone_test_support
+    estimator_replay_support
+    Eigen3::Eigen
+)
+target_compile_definitions(test_estimator_replay PRIVATE
+    DRONE_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
+drone_register_gtest(test_estimator_replay "unit;navigation;estimation;replay")
 
 add_executable(test_swarm_security
     test_swarm_security.cpp

--- a/tests/test_ekf.cpp
+++ b/tests/test_ekf.cpp
@@ -93,8 +93,8 @@ TEST_F(EKFTest, ZUPTClearsVelocity) {
 }
 
 TEST_F(EKFTest, LongStationaryPropagationRemainsFiniteAndNormalized) {
-    const auto s = propagate_constant(
-        ekf_, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero(), 0.0025, 4000);
+    const auto s = propagate_constant(ekf_, Eigen::Vector3d{0.0, 0.0, 9.81},
+                                      Eigen::Vector3d::Zero(), 0.0025, 4000);
     const auto diagnostics = ekf_.diagnostics();
 
     EXPECT_NEAR(s.position.norm(), 0.0, 0.1);
@@ -197,9 +197,8 @@ TEST_F(EKFTest, ExcessiveImuTimeStepIsRejected) {
 
 TEST_F(EKFTest, NaNImuInputIsRejected) {
     const auto before = ekf_.state();
-    ekf_.propagate_imu(
-        Eigen::Vector3d{std::numeric_limits<double>::quiet_NaN(), 0.0, 9.81},
-        Eigen::Vector3d::Zero(), 0.01);
+    ekf_.propagate_imu(Eigen::Vector3d{std::numeric_limits<double>::quiet_NaN(), 0.0, 9.81},
+                       Eigen::Vector3d::Zero(), 0.01);
     const auto after = ekf_.state();
     const auto diagnostics = ekf_.diagnostics();
 

--- a/tests/test_ekf.cpp
+++ b/tests/test_ekf.cpp
@@ -8,6 +8,7 @@
 #include "vio/EKFEstimator.hpp"
 #include <Eigen/Core>
 #include <cmath>
+#include <limits>
 #include <numbers>
 
 using namespace drone::vio;
@@ -88,7 +89,19 @@ TEST_F(EKFTest, ZUPTClearsVelocity) {
 
     ekf_.update_zupt();
     auto s = ekf_.state();
-    EXPECT_NEAR(s.velocity.norm(), 0.0, 0.01);
+    EXPECT_NEAR(s.velocity.norm(), 0.0, 0.05);
+}
+
+TEST_F(EKFTest, LongStationaryPropagationRemainsFiniteAndNormalized) {
+    const auto s = propagate_constant(
+        ekf_, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero(), 0.0025, 4000);
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_NEAR(s.position.norm(), 0.0, 0.1);
+    EXPECT_NEAR(s.velocity.norm(), 0.0, 0.1);
+    EXPECT_NEAR(s.orientation.norm(), 1.0, 1e-9);
+    EXPECT_FALSE(diagnostics.has_non_finite_state);
+    EXPECT_FALSE(diagnostics.has_non_finite_covariance);
 }
 
 //  6. Depth update should correct z position â”€
@@ -96,10 +109,23 @@ TEST_F(EKFTest, DepthUpdateCorrection) {
     // propagate briefly then check depth correction
     propagate_constant(ekf_, Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.0025, 100);
 
-    const double true_depth = 5.0;
+    const double true_depth = 0.12;
     ekf_.update_depth(true_depth, 0.02);
     auto s = ekf_.state();
     EXPECT_NEAR(s.position.z(), true_depth, 0.2);
+}
+
+TEST_F(EKFTest, DepthUpdateOnlyCorrectsForIndependentMeasurement) {
+    propagate_constant(ekf_, Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.0025, 100);
+    const auto before = ekf_.state();
+
+    ekf_.update_depth(before.position.z(), 0.02);
+    const auto unchanged = ekf_.state();
+    EXPECT_NEAR((unchanged.position - before.position).norm(), 0.0, 1.0e-9);
+
+    ekf_.update_depth(before.position.z() + 0.12, 0.05);
+    const auto corrected = ekf_.state();
+    EXPECT_GT(std::abs(corrected.position.z() - before.position.z()), 0.015);
 }
 
 //  7. Covariance must remain symmetric positive-definite
@@ -145,6 +171,167 @@ TEST_F(EKFTest, VisualPoseUpdateChangesState) {
 
     EXPECT_GT((after.position - before.position).norm(), 1.0e-3);
     EXPECT_GT((after.velocity - before.velocity).norm(), 1.0e-3);
+}
+
+TEST_F(EKFTest, TimestampGoingBackwardsIsRejected) {
+    ekf_.propagate_imu(Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.01);
+    const auto before = ekf_.state();
+
+    ekf_.propagate_imu(Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), -0.01);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-12));
+    EXPECT_EQ(diagnostics.timestamp_rejection_count, 1u);
+}
+
+TEST_F(EKFTest, ExcessiveImuTimeStepIsRejected) {
+    const auto before = ekf_.state();
+    ekf_.propagate_imu(Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.2);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-12));
+    EXPECT_EQ(diagnostics.timestamp_rejection_count, 1u);
+}
+
+TEST_F(EKFTest, NaNImuInputIsRejected) {
+    const auto before = ekf_.state();
+    ekf_.propagate_imu(
+        Eigen::Vector3d{std::numeric_limits<double>::quiet_NaN(), 0.0, 9.81},
+        Eigen::Vector3d::Zero(), 0.01);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-12));
+    EXPECT_EQ(diagnostics.invalid_input_count, 1u);
+}
+
+TEST_F(EKFTest, InfiniteMeasurementInputIsRejected) {
+    const auto before = ekf_.state();
+    ekf_.update_depth(std::numeric_limits<double>::infinity(), 0.02);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-12));
+    EXPECT_EQ(diagnostics.invalid_input_count, 1u);
+}
+
+TEST_F(EKFTest, VisionOutlierRejectionLeavesStateUnchanged) {
+    propagate_constant(ekf_, Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.0025, 200);
+    const auto before = ekf_.state();
+    ekf_.update_visual_pose(before.position + Eigen::Vector3d{50.0, -50.0, 20.0},
+                            Eigen::Vector3d{30.0, 0.0, 0.0}, 0.05, 0.05);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-9));
+    EXPECT_TRUE(after.velocity.isApprox(before.velocity, 1e-9));
+    EXPECT_GE(diagnostics.rejected_updates[static_cast<size_t>(EstimatorSensorType::VISUAL_POSE)],
+              1u);
+}
+
+TEST_F(EKFTest, DepthMeasurementOutlierIsRejected) {
+    const auto before = ekf_.state();
+    ekf_.update_depth(500.0, 0.01);
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-9));
+    EXPECT_GE(diagnostics.rejected_updates[static_cast<size_t>(EstimatorSensorType::DEPTH)], 1u);
+}
+
+TEST_F(EKFTest, ZuptPreservesPositionAttitudeAndBiases) {
+    ekf_.reset(Eigen::Vector3d{1.0, 2.0, 3.0},
+               Eigen::Quaterniond(Eigen::AngleAxisd(0.3, Eigen::Vector3d::UnitZ())),
+               Eigen::Vector3d{0.4, -0.2, 0.1});
+    const auto before = ekf_.state();
+
+    ekf_.update_zupt();
+    const auto after = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-9));
+    EXPECT_TRUE(after.orientation.coeffs().isApprox(before.orientation.coeffs(), 1e-9));
+    EXPECT_TRUE(after.accel_bias.isApprox(before.accel_bias, 1e-9));
+    EXPECT_TRUE(after.gyro_bias.isApprox(before.gyro_bias, 1e-9));
+    EXPECT_LT(after.velocity.norm(), before.velocity.norm());
+    EXPECT_LT(diagnostics.covariance_symmetry_error, 1e-9);
+}
+
+TEST_F(EKFTest, CovarianceSymmetryHoldsAfterRepeatedUpdates) {
+    Eigen::Matrix3d K;
+    K << 800, 0, 320, 0, 800, 240, 0, 0, 1;
+    std::vector<Eigen::Vector2d> z{{320, 240}};
+    std::vector<Eigen::Vector3d> pts{{0.0, 0.0, 5.0}};
+
+    for (int i = 0; i < 100; ++i) {
+        ekf_.propagate_imu(Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d{0.0, 0.0, 0.01}, 0.01);
+        ekf_.update_vision(z, pts, K);
+        ekf_.update_depth(0.0, 0.05);
+    }
+
+    const auto diagnostics = ekf_.diagnostics();
+    EXPECT_LT(diagnostics.covariance_symmetry_error, 1e-8);
+    EXPECT_GT(diagnostics.covariance_min_diagonal, 0.0);
+}
+
+TEST_F(EKFTest, CovarianceRemainsFiniteDuringLongPropagation) {
+    for (int i = 0; i < 20000; ++i) {
+        ekf_.propagate_imu(Eigen::Vector3d{0.01, -0.02, 9.81},
+                           Eigen::Vector3d{0.001, 0.002, -0.003}, 0.0025);
+    }
+    const auto diagnostics = ekf_.diagnostics();
+    EXPECT_FALSE(diagnostics.has_non_finite_covariance);
+    EXPECT_FALSE(diagnostics.has_non_finite_state);
+}
+
+TEST_F(EKFTest, DeterministicOutputForIdenticalReplayInput) {
+    EKFEstimator ekf_a;
+    EKFEstimator ekf_b;
+    ekf_a.reset();
+    ekf_b.reset();
+
+    for (int i = 0; i < 400; ++i) {
+        const Eigen::Vector3d accel{0.02, 0.01, 9.81};
+        const Eigen::Vector3d gyro{0.0, 0.0, 0.01};
+        ekf_a.propagate_imu(accel, gyro, 0.0025);
+        ekf_b.propagate_imu(accel, gyro, 0.0025);
+    }
+    ekf_a.update_visual_pose(Eigen::Vector3d{0.3, 0.1, 0.0}, Eigen::Vector3d{0.1, 0.0, 0.0});
+    ekf_b.update_visual_pose(Eigen::Vector3d{0.3, 0.1, 0.0}, Eigen::Vector3d{0.1, 0.0, 0.0});
+    ekf_a.update_depth(0.0, 0.05);
+    ekf_b.update_depth(0.0, 0.05);
+
+    const auto a = ekf_a.state();
+    const auto b = ekf_b.state();
+    EXPECT_TRUE(a.position.isApprox(b.position, 1e-12));
+    EXPECT_TRUE(a.velocity.isApprox(b.velocity, 1e-12));
+    EXPECT_TRUE(a.orientation.coeffs().isApprox(b.orientation.coeffs(), 1e-12));
+}
+
+TEST_F(EKFTest, InvalidMeasurementDoesNotModifyState) {
+    const auto before = ekf_.state();
+    ekf_.update_visual_pose(Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()),
+                            Eigen::Vector3d::Zero(), 0.1, 0.1);
+    const auto after = ekf_.state();
+    EXPECT_TRUE(after.position.isApprox(before.position, 1e-12));
+    EXPECT_TRUE(after.velocity.isApprox(before.velocity, 1e-12));
+}
+
+TEST_F(EKFTest, ResetClearsEstimatorHistoryAndDiagnostics) {
+    ekf_.propagate_imu(Eigen::Vector3d{0, 0, 9.81}, Eigen::Vector3d::Zero(), 0.01);
+    ekf_.update_depth(0.2, 0.05);
+    ASSERT_GT(ekf_.diagnostics().propagation_count, 0u);
+
+    ekf_.reset();
+    const auto state = ekf_.state();
+    const auto diagnostics = ekf_.diagnostics();
+
+    EXPECT_TRUE(state.position.isZero(1e-12));
+    EXPECT_EQ(diagnostics.propagation_count, 0u);
+    EXPECT_EQ(diagnostics.invalid_input_count, 0u);
+    EXPECT_EQ(diagnostics.timestamp_rejection_count, 0u);
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_estimator_replay.cpp
+++ b/tests/test_estimator_replay.cpp
@@ -1,0 +1,254 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
+#include "estimation/ReplayRunner.hpp"
+
+using namespace drone;
+
+namespace {
+
+using json = nlohmann::json;
+
+std::filesystem::path phase15_dataset_path() {
+#ifdef DRONE_SOURCE_DIR
+    return std::filesystem::path(DRONE_SOURCE_DIR) /
+           "datasets/estimator/phase15_stationary_replay.json";
+#else
+    return std::filesystem::path("datasets/estimator/phase15_stationary_replay.json");
+#endif
+}
+
+std::filesystem::path write_json_file(const std::string& name, const json& payload) {
+    const auto path = std::filesystem::temp_directory_path() / name;
+    std::ofstream output(path.string(), std::ios::trunc);
+    EXPECT_TRUE(output.is_open());
+    output << payload.dump(2);
+    output.close();
+    return path;
+}
+
+json baseline_payload() {
+    return json{
+        {"schema_version", 1},
+        {"coordinate_frame", "local_enu"},
+        {"initial_state",
+         {{"position", {0.0, 0.0, 0.0}}, {"velocity", {0.0, 0.0, 0.0}}, {"yaw_rad", 0.0}}},
+        {"records",
+         json::array({
+             {{"type", "imu"},
+              {"timestamp_s", 0.01},
+              {"accel_mps2", {0.0, 0.0, 9.81}},
+              {"gyro_rads", {0.0, 0.0, 0.0}}},
+             {{"type", "imu"},
+              {"timestamp_s", 0.02},
+              {"accel_mps2", {0.0, 0.0, 9.81}},
+              {"gyro_rads", {0.0, 0.0, 0.0}}},
+             {{"type", "depth"}, {"timestamp_s", 0.03}, {"z_world_m", 0.02}, {"sigma_m", 0.05}},
+             {{"type", "visual_pose"},
+              {"timestamp_s", 0.04},
+              {"position_m", {0.01, 0.0, 0.02}},
+              {"velocity_mps", {0.0, 0.0, 0.0}},
+              {"sigma_position_m", 0.2},
+              {"sigma_velocity_mps", 0.2}},
+         })},
+    };
+}
+
+} // namespace
+
+TEST(EstimatorReplay, ActiveOnlySucceedsOnPhase15Dataset) {
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(phase15_dataset_path(), config);
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_TRUE(result.report.success);
+    EXPECT_EQ(result.report.replay_mode, "active_only");
+}
+
+TEST(EstimatorReplay, RepeatingReplayProducesSameHash) {
+    const auto path = write_json_file("replay_repeat_phase16b.json", baseline_payload());
+    estimation::ReplayRunConfig config;
+    const auto a = estimation::run_replay_file(path, config);
+    const auto b = estimation::run_replay_file(path, config);
+    EXPECT_EQ(a.exit_code, 0);
+    EXPECT_EQ(b.exit_code, 0);
+    EXPECT_EQ(a.report.deterministic_result_hash, b.report.deterministic_result_hash);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, ChangingMeasurementChangesHash) {
+    auto payload_a = baseline_payload();
+    auto payload_b = baseline_payload();
+    payload_b["records"][1]["accel_mps2"][0] = 0.2;
+    const auto path_a = write_json_file("replay_hash_a_phase16b.json", payload_a);
+    const auto path_b = write_json_file("replay_hash_b_phase16b.json", payload_b);
+
+    estimation::ReplayRunConfig config;
+    const auto a = estimation::run_replay_file(path_a, config);
+    const auto b = estimation::run_replay_file(path_b, config);
+    EXPECT_EQ(a.exit_code, 0);
+    EXPECT_EQ(b.exit_code, 0);
+    EXPECT_NE(a.report.deterministic_result_hash, b.report.deterministic_result_hash);
+
+    std::filesystem::remove(path_a);
+    std::filesystem::remove(path_b);
+}
+
+TEST(EstimatorReplay, IdenticalShadowKeepsActiveStateCompatible) {
+    const auto path = write_json_file("replay_shadow_phase16b.json", baseline_payload());
+
+    estimation::ReplayRunConfig active_only;
+    estimation::ReplayRunConfig with_shadow;
+    with_shadow.mode = estimation::ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW;
+
+    const auto a = estimation::run_replay_file(path, active_only);
+    const auto b = estimation::run_replay_file(path, with_shadow);
+    EXPECT_EQ(a.exit_code, 0);
+    EXPECT_EQ(b.exit_code, 0);
+    EXPECT_TRUE(a.report.final_pose.position.isApprox(b.report.final_pose.position, 1e-12));
+    EXPECT_TRUE(a.report.final_pose.velocity.isApprox(b.report.final_pose.velocity, 1e-12));
+    EXPECT_LT(b.report.active_shadow_position_delta_m, 1e-9);
+
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, MalformedJsonFails) {
+    const auto path = std::filesystem::temp_directory_path() / "replay_malformed_phase16b.json";
+    std::ofstream output(path.string(), std::ios::trunc);
+    ASSERT_TRUE(output.is_open());
+    output << "{ invalid";
+    output.close();
+
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_FALSE(result.report.success);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, UnknownSchemaVersionFails) {
+    auto payload = baseline_payload();
+    payload["schema_version"] = 99;
+    const auto path = write_json_file("replay_bad_schema_phase16b.json", payload);
+
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_FALSE(result.report.success);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, OversizedInputFails) {
+    const auto path = write_json_file("replay_oversized_phase16b.json", baseline_payload());
+    estimation::ReplayRunConfig config;
+    config.limits.max_file_bytes = 32;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, ExcessiveRecordCountFails) {
+    auto payload = baseline_payload();
+    payload["records"] = json::array();
+    for (int i = 0; i < 5; ++i) {
+        payload["records"].push_back(
+            {{"type", "imu"},
+             {"timestamp_s", 0.01 * static_cast<double>(i + 1)},
+             {"accel_mps2", {0.0, 0.0, 9.81}},
+             {"gyro_rads", {0.0, 0.0, 0.0}}});
+    }
+    const auto path = write_json_file("replay_record_limit_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    config.limits.max_record_count = 2;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, BackwardTimestampFails) {
+    auto payload = baseline_payload();
+    payload["records"][1]["timestamp_s"] = 0.005;
+    const auto path = write_json_file("replay_backwards_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_EQ(result.report.timestamp_violation_count, 1u);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, InvalidCovarianceFails) {
+    auto payload = baseline_payload();
+    payload["records"][3]["sigma_position_m"] = -1.0;
+    const auto path = write_json_file("replay_bad_cov_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, NonFiniteValueFails) {
+    auto payload = baseline_payload();
+    payload["records"][0]["accel_mps2"][0] = "NaN";
+    const auto path = write_json_file("replay_nan_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_FALSE(result.report.success);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, InvalidQuaternionFails) {
+    auto payload = baseline_payload();
+    payload["records"][3]["orientation_wxyz"] = {0.0, 0.0, 0.0, 0.0};
+    const auto path = write_json_file("replay_bad_quat_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, UnsupportedMeasurementFailsWithNonZeroStatus) {
+    auto payload = baseline_payload();
+    payload["records"][2]["type"] = "loop_closure";
+    const auto path = write_json_file("replay_unsupported_measurement_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    EXPECT_FALSE(result.report.success);
+    EXPECT_GT(result.report.unsupported_measurement_count, 0u);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, UnsupportedFrameFails) {
+    auto payload = baseline_payload();
+    payload["coordinate_frame"] = "map_magic";
+    const auto path = write_json_file("replay_bad_frame_phase16b.json", payload);
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    EXPECT_NE(result.exit_code, 0);
+    std::filesystem::remove(path);
+}
+
+TEST(EstimatorReplay, ReportContainsRequiredFields) {
+    const auto path = write_json_file("replay_report_phase16b.json", baseline_payload());
+    estimation::ReplayRunConfig config;
+    const auto result = estimation::run_replay_file(path, config);
+    ASSERT_EQ(result.exit_code, 0);
+
+    const auto output = nlohmann::json::parse(estimation::replay_report_json(result.report));
+    EXPECT_TRUE(output.contains("report_schema_version"));
+    EXPECT_TRUE(output.contains("replay_mode"));
+    EXPECT_TRUE(output.contains("deterministic_result_hash"));
+    EXPECT_TRUE(output.contains("final_position_m"));
+    EXPECT_TRUE(output.contains("success"));
+
+    std::filesystem::remove(path);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_estimator_replay.cpp
+++ b/tests/test_estimator_replay.cpp
@@ -154,11 +154,10 @@ TEST(EstimatorReplay, ExcessiveRecordCountFails) {
     auto payload = baseline_payload();
     payload["records"] = json::array();
     for (int i = 0; i < 5; ++i) {
-        payload["records"].push_back(
-            {{"type", "imu"},
-             {"timestamp_s", 0.01 * static_cast<double>(i + 1)},
-             {"accel_mps2", {0.0, 0.0, 9.81}},
-             {"gyro_rads", {0.0, 0.0, 0.0}}});
+        payload["records"].push_back({{"type", "imu"},
+                                      {"timestamp_s", 0.01 * static_cast<double>(i + 1)},
+                                      {"accel_mps2", {0.0, 0.0, 9.81}},
+                                      {"gyro_rads", {0.0, 0.0, 0.0}}});
     }
     const auto path = write_json_file("replay_record_limit_phase16b.json", payload);
     estimation::ReplayRunConfig config;

--- a/tests/test_estimator_shadow.cpp
+++ b/tests/test_estimator_shadow.cpp
@@ -1,0 +1,623 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <stop_token>
+#include <thread>
+
+#include "estimation/EstimatorCoordinator.hpp"
+#include "estimation/MeasurementAdapters.hpp"
+#include "estimation/MinimalEskfAdapter.hpp"
+#include "runtime/RuntimeMode.hpp"
+
+using namespace drone;
+
+namespace {
+
+estimation::EstimatorMeasurement make_imu_measurement(uint64_t sequence_id, double timestamp_s,
+                                                      const Eigen::Vector3d& accel,
+                                                      const Eigen::Vector3d& gyro) {
+    estimation::EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = estimation::SensorSource::IMU;
+    measurement.header.frame = estimation::CoordinateFrame::BODY;
+    measurement.header.type = estimation::MeasurementType::IMU;
+    measurement.data = estimation::ImuMeasurementData{accel, gyro};
+    return measurement;
+}
+
+estimation::EstimatorMeasurement make_visual_measurement(uint64_t sequence_id, double timestamp_s) {
+    estimation::EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = estimation::SensorSource::VISUAL_FRONTEND;
+    measurement.header.frame = estimation::CoordinateFrame::WORLD;
+    measurement.header.type = estimation::MeasurementType::VISUAL_POSE;
+
+    estimation::VisualPoseMeasurementData visual;
+    visual.position = Eigen::Vector3d{0.2, -0.1, 0.05};
+    visual.velocity = Eigen::Vector3d{0.05, 0.0, 0.0};
+    visual.orientation = Eigen::Quaterniond::Identity();
+    visual.quality = 0.85;
+    visual.covariance.dimension = 6;
+    visual.covariance.matrix.setZero();
+    visual.covariance.matrix.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity() * 0.04;
+    visual.covariance.matrix.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * 0.04;
+    measurement.data = visual;
+    return measurement;
+}
+
+class ControlledTestEstimator final : public estimation::StateEstimator {
+public:
+    explicit ControlledTestEstimator(std::string name) : name_(std::move(name)) {}
+
+    void set_process_delay(std::chrono::milliseconds delay) {
+        process_delay_ = delay;
+    }
+
+    void set_failure_after(uint64_t accepted_processes) {
+        failure_after_ = accepted_processes;
+    }
+
+    void set_position_bias(const Eigen::Vector3d& bias) {
+        position_bias_ = bias;
+    }
+
+    void set_sequence_offset(int64_t offset) {
+        sequence_offset_ = offset;
+    }
+
+    void set_external_reset_count(std::shared_ptr<std::atomic<uint64_t>> reset_count) {
+        external_reset_count_ = std::move(reset_count);
+    }
+
+    [[nodiscard]] uint64_t reset_count() const {
+        return reset_count_.load();
+    }
+
+    void reset(const estimation::EstimatorInitialState& initial) override {
+        std::lock_guard lock(mutex_);
+        ++reset_count_;
+        if (external_reset_count_) {
+            external_reset_count_->store(reset_count_.load());
+        }
+        process_count_ = 0;
+        snapshot_ = {};
+        snapshot_.pose.position = initial.position;
+        snapshot_.pose.velocity = initial.velocity;
+        snapshot_.pose.orientation = initial.orientation;
+        snapshot_.pose.timestamp = 0.0;
+        snapshot_.diagnostics.health_state = vio::EstimatorHealthState::INITIALIZING;
+    }
+
+    estimation::EstimatorUpdateResult process(
+        const estimation::EstimatorMeasurement& measurement) override {
+        if (process_delay_.count() > 0) {
+            std::this_thread::sleep_for(process_delay_);
+        }
+
+        std::lock_guard lock(mutex_);
+        ++process_count_;
+        if (failure_after_.has_value() && process_count_ > *failure_after_) {
+            throw std::runtime_error("controlled shadow failure");
+        }
+
+        snapshot_.pose.timestamp = measurement.header.timestamp_s;
+        snapshot_.pose.position =
+            position_bias_ +
+            Eigen::Vector3d{static_cast<double>(measurement.header.sequence_id), 0.0, 0.0};
+        snapshot_.pose.velocity = Eigen::Vector3d::Constant(0.01 * snapshot_.pose.position.x());
+        snapshot_.pose.orientation = Eigen::Quaterniond::Identity();
+        snapshot_.pose.localization_confidence = 0.91;
+        snapshot_.diagnostics.health_state = vio::EstimatorHealthState::NOMINAL;
+        snapshot_.last_sequence_id = static_cast<uint64_t>(
+            static_cast<int64_t>(measurement.header.sequence_id) + sequence_offset_);
+
+        estimation::EstimatorUpdateResult result;
+        result.status = estimation::EstimatorUpdateStatus::ACCEPTED;
+        result.validation.consumed = true;
+        result.validation.status = estimation::MeasurementValidationStatus::ACCEPTED;
+        result.snapshot = snapshot_;
+        return result;
+    }
+
+    [[nodiscard]] estimation::EstimatorSnapshot snapshot() const override {
+        std::lock_guard lock(mutex_);
+        return snapshot_;
+    }
+
+    [[nodiscard]] vio::EstimatorDiagnostics diagnostics() const override {
+        std::lock_guard lock(mutex_);
+        return snapshot_.diagnostics;
+    }
+
+    [[nodiscard]] estimation::EstimatorCapabilities capabilities() const override {
+        estimation::EstimatorCapabilities capabilities;
+        capabilities.set(estimation::EstimatorCapability::IMU_PROPAGATION);
+        return capabilities;
+    }
+
+    [[nodiscard]] std::string_view name() const noexcept override {
+        return name_;
+    }
+
+private:
+    std::string name_;
+    std::chrono::milliseconds process_delay_{0};
+    std::optional<uint64_t> failure_after_{};
+    Eigen::Vector3d position_bias_{Eigen::Vector3d::Zero()};
+    int64_t sequence_offset_{0};
+    std::shared_ptr<std::atomic<uint64_t>> external_reset_count_{};
+
+    mutable std::mutex mutex_;
+    estimation::EstimatorSnapshot snapshot_{};
+    std::atomic<uint64_t> reset_count_{0};
+    uint64_t process_count_{0};
+};
+
+std::filesystem::path write_runtime_file(const std::string& name, const std::string& body) {
+    const auto path = std::filesystem::temp_directory_path() / name;
+    std::ofstream output(path.string(), std::ios::trunc);
+    EXPECT_TRUE(output.is_open());
+    output << body;
+    output.close();
+    return path;
+}
+
+} // namespace
+
+TEST(EstimatorAdapter, MatchesDirectEkfBehavior) {
+    vio::EKFEstimator direct;
+    direct.reset();
+
+    estimation::MinimalEskfAdapter adapter;
+    adapter.reset({});
+
+    for (int i = 0; i < 50; ++i) {
+        const double timestamp_s = 0.0025 * static_cast<double>(i + 1);
+        const auto imu = make_imu_measurement(static_cast<uint64_t>(i + 1), timestamp_s,
+                                              Eigen::Vector3d{0.01, 0.0, 9.81},
+                                              Eigen::Vector3d{0.0, 0.0, 0.01});
+        direct.propagate_imu(Eigen::Vector3d{0.01, 0.0, 9.81}, Eigen::Vector3d{0.0, 0.0, 0.01},
+                             0.0025);
+        static_cast<void>(adapter.process(imu));
+    }
+
+    direct.update_visual_pose(Eigen::Vector3d{0.2, -0.1, 0.05}, Eigen::Vector3d{0.05, 0.0, 0.0},
+                              0.2, 0.2);
+    direct.update_depth(0.05, 0.1);
+    static_cast<void>(adapter.process(make_visual_measurement(60, 0.13)));
+
+    estimation::EstimatorMeasurement depth;
+    depth.header.timestamp_s = 0.131;
+    depth.header.sequence_id = 61;
+    depth.header.source = estimation::SensorSource::DEPTH_SENSOR;
+    depth.header.frame = estimation::CoordinateFrame::WORLD;
+    depth.header.type = estimation::MeasurementType::ALTITUDE;
+    depth.data = estimation::AltitudeMeasurementData{0.05, 0.1};
+    static_cast<void>(adapter.process(depth));
+
+    const auto direct_state = direct.state();
+    const auto adapter_state = adapter.snapshot().pose;
+    EXPECT_TRUE(direct_state.position.isApprox(adapter_state.position, 1e-9));
+    EXPECT_TRUE(direct_state.velocity.isApprox(adapter_state.velocity, 1e-9));
+}
+
+TEST(MeasurementAdapters, PreservesVisualOrientationWithoutConsumption) {
+    const auto adapted = estimation::MeasurementAdapters::adapt_visual_pose(
+        1.0, Eigen::Vector3d{1.0, 2.0, 3.0}, Eigen::Vector3d{0.1, 0.0, 0.0},
+        Eigen::Quaterniond::Identity(), 0.8, true, 7, false);
+
+    ASSERT_TRUE(adapted.measurement.has_value());
+    EXPECT_FALSE(adapted.validation.orientation_consumed);
+    const auto& visual = std::get<estimation::VisualPoseMeasurementData>(adapted.measurement->data);
+    ASSERT_TRUE(visual.orientation.has_value());
+    EXPECT_TRUE(
+        visual.orientation->coeffs().isApprox(Eigen::Quaterniond::Identity().coeffs(), 1e-12));
+}
+
+TEST(MeasurementAdapters, RejectsInvalidTdoaCandidate) {
+    const auto adapted = estimation::MeasurementAdapters::adapt_tdoa_position_candidate(
+        1.0, Eigen::Vector3d{1.0, 2.0, 3.0}, 1.5, 4);
+    EXPECT_FALSE(adapted.measurement.has_value());
+    EXPECT_EQ(adapted.validation.status, estimation::MeasurementValidationStatus::REJECTED_INVALID);
+}
+
+TEST(EstimatorCoordinator, ShadowDisabledLeavesActiveOutputUnchanged) {
+    auto active = std::make_shared<estimation::MinimalEskfAdapter>();
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    for (int i = 0; i < 20; ++i) {
+        static_cast<void>(coordinator.process(make_imu_measurement(
+            static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
+            Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    }
+
+    const auto coordinated = coordinator.active_snapshot().pose;
+
+    estimation::MinimalEskfAdapter direct;
+    direct.reset({});
+    for (int i = 0; i < 20; ++i) {
+        static_cast<void>(direct.process(make_imu_measurement(
+            static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
+            Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    }
+    const auto direct_state = direct.snapshot().pose;
+    EXPECT_TRUE(coordinated.position.isApprox(direct_state.position, 1e-12));
+    EXPECT_TRUE(coordinated.velocity.isApprox(direct_state.velocity, 1e-12));
+}
+
+TEST(EstimatorCoordinator, ShadowEnabledDoesNotChangeActiveOutputAndTracksOverflow) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    shadow_config.max_queue_depth = 2;
+    shadow_config.max_lag_ms = 0.0;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_process_delay(std::chrono::milliseconds(10));
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    auto baseline = std::make_shared<ControlledTestEstimator>("baseline_test");
+    baseline->reset({});
+    for (int i = 0; i < 30; ++i) {
+        const auto imu = make_imu_measurement(static_cast<uint64_t>(i + 1),
+                                              0.0025 * static_cast<double>(i + 1),
+                                              Eigen::Vector3d{0.0, 0.0, 9.81},
+                                              Eigen::Vector3d::Zero());
+        static_cast<void>(coordinator.process(imu));
+        static_cast<void>(baseline->process(imu));
+    }
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+
+    const auto active_state = coordinator.active_snapshot().pose;
+    const auto baseline_state = baseline->snapshot().pose;
+    const auto telemetry = coordinator.telemetry();
+
+    EXPECT_TRUE(active_state.position.isApprox(baseline_state.position, 1e-12));
+    EXPECT_TRUE(active_state.velocity.isApprox(baseline_state.velocity, 1e-12));
+    EXPECT_GT(telemetry.dropped_events, 0u);
+    coordinator.stop_shadow();
+}
+
+TEST(EstimatorCoordinator, ShadowFailureDoesNotStopActiveProcessing) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_failure_after(0);
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    const auto first = coordinator.process(
+        make_imu_measurement(1, 0.01, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero()));
+    const auto second = coordinator.process(
+        make_imu_measurement(2, 0.02, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero()));
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+
+    EXPECT_EQ(first.status, estimation::EstimatorUpdateStatus::ACCEPTED);
+    EXPECT_EQ(second.status, estimation::EstimatorUpdateStatus::ACCEPTED);
+    EXPECT_EQ(coordinator.active_snapshot().last_sequence_id, 2u);
+    EXPECT_EQ(coordinator.telemetry().shadow_health, estimation::ShadowHealthState::FAILED);
+}
+
+TEST(EstimatorCoordinator, ActiveProcessingDoesNotWaitForDelayedShadow) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    shadow_config.max_lag_ms = 5.0;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_process_delay(std::chrono::milliseconds(75));
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    const auto started_at = std::chrono::steady_clock::now();
+    static_cast<void>(coordinator.process(
+        make_imu_measurement(1, 0.01, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    const auto elapsed_ms = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - started_at)
+                                .count();
+
+    EXPECT_LT(elapsed_ms, 30.0);
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+    EXPECT_EQ(coordinator.telemetry().shadow_health, estimation::ShadowHealthState::LAGGING);
+}
+
+TEST(EstimatorCoordinator, ShadowQueueDropsBecomeStaleAfterDrain) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    shadow_config.max_queue_depth = 1;
+    shadow_config.max_lag_ms = 1.0;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_process_delay(std::chrono::milliseconds(20));
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    for (uint64_t i = 1; i <= 16; ++i) {
+        static_cast<void>(coordinator.process(
+            make_imu_measurement(i, 0.01 * static_cast<double>(i), Eigen::Vector3d{0.0, 0.0, 9.81},
+                                 Eigen::Vector3d::Zero())));
+    }
+
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+    const auto telemetry = coordinator.telemetry();
+    EXPECT_GT(telemetry.dropped_events, 0u);
+    EXPECT_EQ(telemetry.shadow_health, estimation::ShadowHealthState::STALE);
+    EXPECT_GE(telemetry.queue_high_water_mark, 1u);
+}
+
+TEST(EstimatorCoordinator, ReconfigureShadowResetsNewShadowInstance) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    auto first_shadow = std::make_unique<ControlledTestEstimator>("shadow_one");
+    auto first_shadow_reset_count = std::make_shared<std::atomic<uint64_t>>(0);
+    auto second_shadow_reset_count = std::make_shared<std::atomic<uint64_t>>(0);
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    first_shadow->set_external_reset_count(first_shadow_reset_count);
+    coordinator.configure_shadow(shadow_config, std::move(first_shadow));
+
+    auto second_shadow = std::make_unique<ControlledTestEstimator>("shadow_two");
+    second_shadow->set_external_reset_count(second_shadow_reset_count);
+    coordinator.configure_shadow(shadow_config, std::move(second_shadow));
+
+    EXPECT_GE(first_shadow_reset_count->load(), 1u);
+    EXPECT_GE(second_shadow_reset_count->load(), 1u);
+    EXPECT_EQ(coordinator.telemetry().shadow_estimator_name, "shadow_two");
+}
+
+TEST(EstimatorCoordinator, StopBeforeStartAndDoubleStopAreSafe) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+
+    coordinator.stop_shadow();
+    coordinator.stop_shadow();
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    coordinator.reset({});
+    coordinator.configure_shadow(std::move(shadow_config),
+                                 std::make_unique<ControlledTestEstimator>("shadow_test"));
+    coordinator.stop_shadow();
+    coordinator.stop_shadow();
+
+    EXPECT_EQ(coordinator.telemetry().shadow_health, estimation::ShadowHealthState::STOPPED);
+}
+
+TEST(EstimatorCoordinator, TelemetryReadsRemainSafeDuringConcurrentProcessing) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_process_delay(std::chrono::milliseconds(3));
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    std::jthread reader([&coordinator](std::stop_token stop_token) {
+        while (!stop_token.stop_requested()) {
+            static_cast<void>(coordinator.telemetry());
+            static_cast<void>(coordinator.active_snapshot());
+            static_cast<void>(coordinator.shadow_snapshot());
+        }
+    });
+
+    for (uint64_t i = 1; i <= 64; ++i) {
+        static_cast<void>(coordinator.process(
+            make_imu_measurement(i, 0.0025 * static_cast<double>(i),
+                                 Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    }
+
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+    reader.request_stop();
+    EXPECT_GE(coordinator.telemetry().queue_high_water_mark, 1u);
+}
+
+TEST(EstimatorCoordinator, MismatchedShadowHistorySkipsComparison) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_sequence_offset(-1);
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    static_cast<void>(coordinator.process(
+        make_imu_measurement(5, 0.05, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+
+    const auto telemetry = coordinator.telemetry();
+    EXPECT_FALSE(telemetry.comparable);
+    EXPECT_GT(telemetry.skipped_comparison_count, 0u);
+}
+
+TEST(EstimatorCoordinator, ShadowPoseNeverBecomesAuthoritativePose) {
+    auto active = std::make_shared<ControlledTestEstimator>("active_test");
+    estimation::EstimatorCoordinator coordinator(
+        std::static_pointer_cast<estimation::StateEstimator>(active));
+    coordinator.reset({});
+
+    estimation::ShadowEstimatorConfig shadow_config;
+    shadow_config.enabled = true;
+    auto shadow = std::make_unique<ControlledTestEstimator>("shadow_test");
+    shadow->set_position_bias(Eigen::Vector3d{100.0, 0.0, 0.0});
+    coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
+
+    static_cast<void>(coordinator.process(
+        make_imu_measurement(3, 0.03, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+    ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
+
+    EXPECT_NEAR(coordinator.active_snapshot().pose.position.x(), 3.0, 1e-12);
+    ASSERT_TRUE(coordinator.shadow_snapshot().has_value());
+    EXPECT_GT(coordinator.shadow_snapshot()->pose.position.x(), 100.0);
+}
+
+TEST(RuntimeMode, RejectsUnsupportedHybridActiveConfiguration) {
+    const auto temp_path = write_runtime_file(
+        "runtime_hybrid_active_phase16.json",
+        R"({
+  "runtime_mode": "production",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "hybrid_active",
+    "enable_experimental_hybrid": false,
+    "enable_fej": false,
+    "enable_msckf": false,
+    "enable_loop_closure_correction": false,
+    "enable_automatic_zupt": false
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_TRUE(result.loaded);
+    EXPECT_FALSE(result.estimator_config_valid);
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, ShadowRemainsDisabledByDefault) {
+    const auto temp_path = write_runtime_file(
+        "runtime_phase16_default_shadow.json",
+        R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "minimal"
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_TRUE(result.loaded);
+    EXPECT_FALSE(result.estimator_shadow_requested);
+    EXPECT_FALSE(result.estimator_enable_shadow_estimator);
+    EXPECT_FALSE(result.estimator_shadow_effective);
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, RejectsUnknownEstimatorMode) {
+    const auto temp_path = write_runtime_file(
+        "runtime_phase16_unknown_mode.json",
+        R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "mystery"
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_FALSE(result.estimator_config_valid);
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, RejectsInvalidShadowLimitsAndImplementation) {
+    const auto temp_path = write_runtime_file(
+        "runtime_phase16_bad_shadow.json",
+        R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "minimal",
+    "shadow": {
+      "enabled": true,
+      "implementation": "mystery_shadow",
+      "max_queue_depth": 0,
+      "max_lag_ms": -5.0,
+      "position_divergence_m": 0.25,
+      "velocity_divergence_mps": 0.2,
+      "orientation_divergence_deg": 5.0,
+      "required_consecutive_divergent_samples": 0
+    }
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_FALSE(result.estimator_config_valid);
+    EXPECT_TRUE(result.estimator_shadow_requested);
+    EXPECT_FALSE(result.estimator_shadow_effective);
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, RejectsDisabledExperimentalFeatures) {
+    const auto temp_path = write_runtime_file(
+        "runtime_phase16_bad_experimental_flags.json",
+        R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "minimal",
+    "enable_fej": true,
+    "enable_msckf": true,
+    "enable_loop_closure_correction": true,
+    "enable_automatic_zupt": true
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_FALSE(result.estimator_config_valid);
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, ShadowReportsEffectiveWhenValidAndSupported) {
+    const auto temp_path = write_runtime_file(
+        "runtime_phase16_shadow_enabled.json",
+        R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config/anchors.json",
+  "estimator": {
+    "mode": "minimal",
+    "shadow": {
+      "enabled": true,
+      "comparison_enabled": true,
+      "implementation": "minimal_eskf_clone",
+      "max_queue_depth": 8,
+      "max_lag_ms": 100.0,
+      "position_divergence_m": 0.25,
+      "velocity_divergence_mps": 0.2,
+      "orientation_divergence_deg": 5.0,
+      "required_consecutive_divergent_samples": 10
+    }
+  }
+})");
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_TRUE(result.estimator_config_valid);
+    EXPECT_TRUE(result.estimator_shadow_requested);
+    EXPECT_EQ(result.estimator_enable_shadow_estimator,
+              result.estimator_shadow_compile_time_supported);
+    EXPECT_EQ(result.estimator_shadow_effective, result.estimator_shadow_compile_time_supported);
+    std::filesystem::remove(temp_path);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_estimator_shadow.cpp
+++ b/tests/test_estimator_shadow.cpp
@@ -94,8 +94,8 @@ public:
         snapshot_.diagnostics.health_state = vio::EstimatorHealthState::INITIALIZING;
     }
 
-    estimation::EstimatorUpdateResult process(
-        const estimation::EstimatorMeasurement& measurement) override {
+    estimation::EstimatorUpdateResult
+    process(const estimation::EstimatorMeasurement& measurement) override {
         if (process_delay_.count() > 0) {
             std::this_thread::sleep_for(process_delay_);
         }
@@ -179,9 +179,9 @@ TEST(EstimatorAdapter, MatchesDirectEkfBehavior) {
 
     for (int i = 0; i < 50; ++i) {
         const double timestamp_s = 0.0025 * static_cast<double>(i + 1);
-        const auto imu = make_imu_measurement(static_cast<uint64_t>(i + 1), timestamp_s,
-                                              Eigen::Vector3d{0.01, 0.0, 9.81},
-                                              Eigen::Vector3d{0.0, 0.0, 0.01});
+        const auto imu =
+            make_imu_measurement(static_cast<uint64_t>(i + 1), timestamp_s,
+                                 Eigen::Vector3d{0.01, 0.0, 9.81}, Eigen::Vector3d{0.0, 0.0, 0.01});
         direct.propagate_imu(Eigen::Vector3d{0.01, 0.0, 9.81}, Eigen::Vector3d{0.0, 0.0, 0.01},
                              0.0025);
         static_cast<void>(adapter.process(imu));
@@ -234,9 +234,9 @@ TEST(EstimatorCoordinator, ShadowDisabledLeavesActiveOutputUnchanged) {
     coordinator.reset({});
 
     for (int i = 0; i < 20; ++i) {
-        static_cast<void>(coordinator.process(make_imu_measurement(
-            static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
-            Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+        static_cast<void>(coordinator.process(
+            make_imu_measurement(static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
+                                 Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
     }
 
     const auto coordinated = coordinator.active_snapshot().pose;
@@ -244,9 +244,9 @@ TEST(EstimatorCoordinator, ShadowDisabledLeavesActiveOutputUnchanged) {
     estimation::MinimalEskfAdapter direct;
     direct.reset({});
     for (int i = 0; i < 20; ++i) {
-        static_cast<void>(direct.process(make_imu_measurement(
-            static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
-            Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
+        static_cast<void>(direct.process(
+            make_imu_measurement(static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
+                                 Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
     }
     const auto direct_state = direct.snapshot().pose;
     EXPECT_TRUE(coordinated.position.isApprox(direct_state.position, 1e-12));
@@ -270,10 +270,9 @@ TEST(EstimatorCoordinator, ShadowEnabledDoesNotChangeActiveOutputAndTracksOverfl
     auto baseline = std::make_shared<ControlledTestEstimator>("baseline_test");
     baseline->reset({});
     for (int i = 0; i < 30; ++i) {
-        const auto imu = make_imu_measurement(static_cast<uint64_t>(i + 1),
-                                              0.0025 * static_cast<double>(i + 1),
-                                              Eigen::Vector3d{0.0, 0.0, 9.81},
-                                              Eigen::Vector3d::Zero());
+        const auto imu =
+            make_imu_measurement(static_cast<uint64_t>(i + 1), 0.0025 * static_cast<double>(i + 1),
+                                 Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero());
         static_cast<void>(coordinator.process(imu));
         static_cast<void>(baseline->process(imu));
     }
@@ -329,9 +328,9 @@ TEST(EstimatorCoordinator, ActiveProcessingDoesNotWaitForDelayedShadow) {
     const auto started_at = std::chrono::steady_clock::now();
     static_cast<void>(coordinator.process(
         make_imu_measurement(1, 0.01, Eigen::Vector3d{0.0, 0.0, 9.81}, Eigen::Vector3d::Zero())));
-    const auto elapsed_ms = std::chrono::duration<double, std::milli>(
-                                std::chrono::steady_clock::now() - started_at)
-                                .count();
+    const auto elapsed_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started_at)
+            .count();
 
     EXPECT_LT(elapsed_ms, 30.0);
     ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
@@ -353,9 +352,9 @@ TEST(EstimatorCoordinator, ShadowQueueDropsBecomeStaleAfterDrain) {
     coordinator.configure_shadow(std::move(shadow_config), std::move(shadow));
 
     for (uint64_t i = 1; i <= 16; ++i) {
-        static_cast<void>(coordinator.process(
-            make_imu_measurement(i, 0.01 * static_cast<double>(i), Eigen::Vector3d{0.0, 0.0, 9.81},
-                                 Eigen::Vector3d::Zero())));
+        static_cast<void>(coordinator.process(make_imu_measurement(i, 0.01 * static_cast<double>(i),
+                                                                   Eigen::Vector3d{0.0, 0.0, 9.81},
+                                                                   Eigen::Vector3d::Zero())));
     }
 
     ASSERT_TRUE(coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000)));
@@ -482,9 +481,8 @@ TEST(EstimatorCoordinator, ShadowPoseNeverBecomesAuthoritativePose) {
 }
 
 TEST(RuntimeMode, RejectsUnsupportedHybridActiveConfiguration) {
-    const auto temp_path = write_runtime_file(
-        "runtime_hybrid_active_phase16.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_hybrid_active_phase16.json",
+                                              R"({
   "runtime_mode": "production",
   "anchor_config_path": "config/anchors.json",
   "estimator": {
@@ -504,9 +502,8 @@ TEST(RuntimeMode, RejectsUnsupportedHybridActiveConfiguration) {
 }
 
 TEST(RuntimeMode, ShadowRemainsDisabledByDefault) {
-    const auto temp_path = write_runtime_file(
-        "runtime_phase16_default_shadow.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_phase16_default_shadow.json",
+                                              R"({
   "runtime_mode": "bench",
   "anchor_config_path": "config/anchors.json",
   "estimator": {
@@ -523,9 +520,8 @@ TEST(RuntimeMode, ShadowRemainsDisabledByDefault) {
 }
 
 TEST(RuntimeMode, RejectsUnknownEstimatorMode) {
-    const auto temp_path = write_runtime_file(
-        "runtime_phase16_unknown_mode.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_phase16_unknown_mode.json",
+                                              R"({
   "runtime_mode": "bench",
   "anchor_config_path": "config/anchors.json",
   "estimator": {
@@ -539,9 +535,8 @@ TEST(RuntimeMode, RejectsUnknownEstimatorMode) {
 }
 
 TEST(RuntimeMode, RejectsInvalidShadowLimitsAndImplementation) {
-    const auto temp_path = write_runtime_file(
-        "runtime_phase16_bad_shadow.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_phase16_bad_shadow.json",
+                                              R"({
   "runtime_mode": "bench",
   "anchor_config_path": "config/anchors.json",
   "estimator": {
@@ -567,9 +562,8 @@ TEST(RuntimeMode, RejectsInvalidShadowLimitsAndImplementation) {
 }
 
 TEST(RuntimeMode, RejectsDisabledExperimentalFeatures) {
-    const auto temp_path = write_runtime_file(
-        "runtime_phase16_bad_experimental_flags.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_phase16_bad_experimental_flags.json",
+                                              R"({
   "runtime_mode": "bench",
   "anchor_config_path": "config/anchors.json",
   "estimator": {
@@ -587,9 +581,8 @@ TEST(RuntimeMode, RejectsDisabledExperimentalFeatures) {
 }
 
 TEST(RuntimeMode, ShadowReportsEffectiveWhenValidAndSupported) {
-    const auto temp_path = write_runtime_file(
-        "runtime_phase16_shadow_enabled.json",
-        R"({
+    const auto temp_path = write_runtime_file("runtime_phase16_shadow_enabled.json",
+                                              R"({
   "runtime_mode": "bench",
   "anchor_config_path": "config/anchors.json",
   "estimator": {

--- a/tests/test_navigation_intelligence.cpp
+++ b/tests/test_navigation_intelligence.cpp
@@ -154,6 +154,25 @@ TEST(LocalizationFusion, MarksLocalizationLostWhenCameraAndSyncCollapse) {
     EXPECT_LT(output.confidence, 0.22);
 }
 
+TEST(LocalizationFusion, RejectsNonFiniteTdoaInput) {
+    localization::LocalizationFusion fusion;
+    localization::LocalizationFusionInput input;
+    input.vio_pose.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+    input.vio_pose.drift_m = 0.5;
+    input.vio_pose.localization_confidence = 0.8;
+    input.camera_available = true;
+
+    localization::TDOALocalizer::Solution tdoa_solution;
+    tdoa_solution.position =
+        Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    tdoa_solution.confidence = 0.9;
+    input.tdoa_solution = tdoa_solution;
+
+    const auto output = fusion.update(input);
+    EXPECT_EQ(output.source, "vision-inertial");
+    EXPECT_DOUBLE_EQ(output.tdoa_weight, 0.0);
+}
+
 TEST(OccupancyGridMap, TracksAnchorAndObstacleCoverage) {
     slam::OccupancyGridMap map;
     sensors::LidarMeasurement scan;
@@ -293,6 +312,42 @@ TEST(RuntimeMode, RuntimeFileLoadsEscapedPaths) {
     EXPECT_EQ(result.anchor_config_path, "config/anchors.json");
     EXPECT_EQ(result.lidar_config_path, "config/lidar.json");
     EXPECT_EQ(result.detector_labels_path, "config/detector_labels.json");
+
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RuntimeMode, RuntimeFileLoadsEstimatorValidationDefaults) {
+    const auto temp_path = std::filesystem::temp_directory_path() / "runtime_estimator.json";
+    {
+        std::ofstream output(temp_path.string(), std::ios::trunc);
+        ASSERT_TRUE(output.is_open());
+        output << R"({
+  "runtime_mode": "bench",
+  "anchor_config_path": "config\/anchors.json",
+  "lidar_config_path": "config\/lidar.json",
+  "detector_labels_path": "config\/detector_labels.json",
+  "estimator": {
+    "mode": "minimal",
+    "enable_experimental_hybrid": false,
+    "enable_fej": false,
+    "enable_msckf": false,
+    "enable_loop_closure_correction": false,
+    "enable_automatic_zupt": false,
+    "reject_non_finite_measurements": true,
+    "require_monotonic_timestamps": true,
+    "max_imu_dt_s": 0.1,
+    "diagnostics_enabled": true
+  }
+})";
+    }
+
+    const auto result = runtime::load_runtime_file(temp_path.string());
+    EXPECT_TRUE(result.loaded);
+    EXPECT_TRUE(result.estimator_config_present);
+    EXPECT_TRUE(result.estimator_config_valid);
+    EXPECT_EQ(result.estimator_mode, "minimal");
+    EXPECT_FALSE(result.estimator_enable_experimental_hybrid);
+    EXPECT_DOUBLE_EQ(result.estimator_max_imu_dt_s, 0.1);
 
     std::filesystem::remove(temp_path);
 }

--- a/tests/test_navigation_intelligence.cpp
+++ b/tests/test_navigation_intelligence.cpp
@@ -163,8 +163,7 @@ TEST(LocalizationFusion, RejectsNonFiniteTdoaInput) {
     input.camera_available = true;
 
     localization::TDOALocalizer::Solution tdoa_solution;
-    tdoa_solution.position =
-        Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    tdoa_solution.position = Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
     tdoa_solution.confidence = 0.9;
     input.tdoa_solution = tdoa_solution;
 

--- a/tools/estimator_replay_runner.cpp
+++ b/tools/estimator_replay_runner.cpp
@@ -1,0 +1,59 @@
+#include "estimation/ReplayRunner.hpp"
+
+#include <fstream>
+#include <iostream>
+
+namespace {
+
+void print_usage() {
+    std::cerr << "Usage: estimator_replay_runner --input <path> --output <path> "
+                 "[--mode active_only|active_with_identical_shadow]\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::filesystem::path input_path;
+    std::filesystem::path output_path;
+    drone::estimation::ReplayMode mode = drone::estimation::ReplayMode::ACTIVE_ONLY;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view arg = argv[i];
+        if (arg == "--input" && i + 1 < argc) {
+            input_path = argv[++i];
+        } else if (arg == "--output" && i + 1 < argc) {
+            output_path = argv[++i];
+        } else if (arg == "--mode" && i + 1 < argc) {
+            const std::string value = argv[++i];
+            if (value == "active_only") {
+                mode = drone::estimation::ReplayMode::ACTIVE_ONLY;
+            } else if (value == "active_with_identical_shadow") {
+                mode = drone::estimation::ReplayMode::ACTIVE_WITH_IDENTICAL_SHADOW;
+            } else {
+                std::cerr << "Unsupported mode: " << value << '\n';
+                return 2;
+            }
+        } else {
+            print_usage();
+            return 2;
+        }
+    }
+
+    if (input_path.empty() || output_path.empty()) {
+        print_usage();
+        return 2;
+    }
+
+    drone::estimation::ReplayRunConfig config;
+    config.mode = mode;
+    const auto result = drone::estimation::run_replay_file(input_path, config);
+
+    std::ofstream output(output_path, std::ios::trunc);
+    if (!output.is_open()) {
+        std::cerr << "Could not open output file: " << output_path.string() << '\n';
+        return 3;
+    }
+    output << drone::estimation::replay_report_json(result.report);
+    output.close();
+    return result.exit_code;
+}

--- a/tools/estimator_shadow_benchmark.cpp
+++ b/tools/estimator_shadow_benchmark.cpp
@@ -1,0 +1,569 @@
+#include "estimation/EstimatorCoordinator.hpp"
+#include "estimation/MinimalEskfAdapter.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace drone::estimation {
+namespace {
+
+using json = nlohmann::json;
+
+struct LatencyStats {
+    double mean_us{0.0};
+    double median_us{0.0};
+    double p95_us{0.0};
+    double p99_us{0.0};
+    double min_us{0.0};
+    double max_us{0.0};
+    double stddev_us{0.0};
+    size_t sample_count{0};
+};
+
+struct BenchmarkScenarioConfig {
+    std::string mode;
+    size_t warmup_iteration_count{250};
+    size_t measured_iteration_count{2000};
+    std::chrono::milliseconds shadow_delay{0};
+    size_t queue_depth{512};
+    double max_lag_ms{100.0};
+    size_t throttle_queue_depth{0};
+    bool wait_for_shadow_idle_each_iteration{false};
+};
+
+struct BenchmarkScenarioResult {
+    BenchmarkScenarioConfig config{};
+    bool success{false};
+    std::string failure_reason{"none"};
+    LatencyStats active_process_latency{};
+    LatencyStats shadow_processing_latency{};
+    double active_path_regression_percent{0.0};
+    size_t shadow_queue_high_water_mark{0};
+    uint64_t shadow_dropped_event_count{0};
+    double shadow_lag_ms{0.0};
+    std::string shadow_health{"disabled"};
+    double shutdown_time_ms{0.0};
+    bool active_output_matches_baseline{true};
+    double warmup_duration_ms{0.0};
+    double measured_duration_ms{0.0};
+    double total_duration_ms{0.0};
+    std::vector<double> active_process_samples_us{};
+    std::vector<double> shadow_processing_samples_us{};
+};
+
+struct BenchmarkCliOptions {
+    std::optional<std::filesystem::path> output_path{};
+    std::string scenario{"all"};
+    size_t warmup_iteration_count{250};
+    size_t measured_iteration_count{2000};
+    bool emit_samples{false};
+};
+
+class DelayedShadowEstimator final : public StateEstimator {
+public:
+    DelayedShadowEstimator(vio::EKFConfig config, std::chrono::milliseconds delay)
+        : inner_(config), delay_(delay) {}
+
+    void set_validation_config(const vio::EstimatorValidationConfig& config) {
+        validation_ = config;
+        inner_.set_validation_config(validation_);
+    }
+
+    void reset(const EstimatorInitialState& initial) override {
+        inner_.reset(initial);
+    }
+
+    EstimatorUpdateResult process(const EstimatorMeasurement& measurement) override {
+        if (delay_.count() > 0) {
+            std::this_thread::sleep_for(delay_);
+        }
+        const auto started_at = std::chrono::steady_clock::now();
+        auto result = inner_.process(measurement);
+        last_processing_latency_us_.store(
+            std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - started_at)
+                .count(),
+            std::memory_order_relaxed);
+        return result;
+    }
+
+    [[nodiscard]] EstimatorSnapshot snapshot() const override {
+        return inner_.snapshot();
+    }
+
+    [[nodiscard]] vio::EstimatorDiagnostics diagnostics() const override {
+        return inner_.diagnostics();
+    }
+
+    [[nodiscard]] EstimatorCapabilities capabilities() const override {
+        return inner_.capabilities();
+    }
+
+    [[nodiscard]] std::string_view name() const noexcept override {
+        return "delayed_minimal_eskf_shadow";
+    }
+
+    [[nodiscard]] double last_processing_latency_us() const {
+        return last_processing_latency_us_.load(std::memory_order_relaxed);
+    }
+
+private:
+    MinimalEskfAdapter inner_;
+    vio::EstimatorValidationConfig validation_{};
+    std::chrono::milliseconds delay_{0};
+    std::atomic<double> last_processing_latency_us_{0.0};
+};
+
+EstimatorMeasurement make_imu_measurement(uint64_t sequence_id, double timestamp_s) {
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::IMU;
+    measurement.header.frame = CoordinateFrame::BODY;
+    measurement.header.type = MeasurementType::IMU;
+    measurement.data = ImuMeasurementData{Eigen::Vector3d{0.02, 0.0, 9.81},
+                                          Eigen::Vector3d{0.0, 0.0, 0.01}};
+    return measurement;
+}
+
+EstimatorMeasurement make_visual_measurement(uint64_t sequence_id, double timestamp_s) {
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::VISUAL_FRONTEND;
+    measurement.header.frame = CoordinateFrame::WORLD;
+    measurement.header.type = MeasurementType::VISUAL_POSE;
+
+    VisualPoseMeasurementData visual;
+    visual.position = Eigen::Vector3d{0.1, 0.0, 0.04};
+    visual.velocity = Eigen::Vector3d{0.01, 0.0, 0.0};
+    visual.quality = 0.9;
+    visual.covariance.dimension = 6;
+    visual.covariance.matrix.setZero();
+    visual.covariance.matrix.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity() * 0.04;
+    visual.covariance.matrix.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * 0.04;
+    measurement.data = visual;
+    return measurement;
+}
+
+EstimatorMeasurement make_depth_measurement(uint64_t sequence_id, double timestamp_s) {
+    EstimatorMeasurement measurement;
+    measurement.header.timestamp_s = timestamp_s;
+    measurement.header.sequence_id = sequence_id;
+    measurement.header.source = SensorSource::DEPTH_SENSOR;
+    measurement.header.frame = CoordinateFrame::WORLD;
+    measurement.header.type = MeasurementType::ALTITUDE;
+    measurement.data = AltitudeMeasurementData{0.03, 0.05};
+    return measurement;
+}
+
+double percentile_from_sorted(const std::vector<double>& values, double percentile) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    const auto scaled = percentile * static_cast<double>(values.size() - 1);
+    return values[static_cast<size_t>(std::round(scaled))];
+}
+
+LatencyStats compute_stats(std::vector<double> values) {
+    LatencyStats stats;
+    if (values.empty()) {
+        return stats;
+    }
+    std::sort(values.begin(), values.end());
+    stats.sample_count = values.size();
+    stats.mean_us =
+        std::accumulate(values.begin(), values.end(), 0.0) / static_cast<double>(values.size());
+    stats.median_us = percentile_from_sorted(values, 0.50);
+    stats.p95_us = percentile_from_sorted(values, 0.95);
+    stats.p99_us = percentile_from_sorted(values, 0.99);
+    stats.min_us = values.front();
+    stats.max_us = values.back();
+
+    double sum_sq = 0.0;
+    for (const double value : values) {
+        const double delta = value - stats.mean_us;
+        sum_sq += delta * delta;
+    }
+    stats.stddev_us = std::sqrt(sum_sq / static_cast<double>(values.size()));
+    return stats;
+}
+
+std::string shadow_health_to_string(ShadowHealthState state) {
+    switch (state) {
+    case ShadowHealthState::DISABLED:
+        return "disabled";
+    case ShadowHealthState::STARTING:
+        return "starting";
+    case ShadowHealthState::SYNCHRONIZED:
+        return "synchronized";
+    case ShadowHealthState::LAGGING:
+        return "lagging";
+    case ShadowHealthState::STALE:
+        return "stale";
+    case ShadowHealthState::DIVERGED:
+        return "diverged";
+    case ShadowHealthState::FAILED:
+        return "failed";
+    case ShadowHealthState::STOPPED:
+        return "stopped";
+    }
+    return "unknown";
+}
+
+bool scenario_uses_shadow(std::string_view mode) {
+    return mode == "active_with_shadow" || mode == "shadow_overload";
+}
+
+void process_iteration_batch(EstimatorCoordinator& coordinator, MinimalEskfAdapter& baseline,
+                             std::shared_ptr<DelayedShadowEstimator> delayed_shadow,
+                             uint64_t& next_sequence_id, size_t iteration_count,
+                             std::vector<double>* active_latencies,
+                             std::vector<double>* shadow_latencies,
+                             const BenchmarkScenarioConfig& config) {
+    for (size_t i = 0; i < iteration_count; ++i) {
+        const uint64_t sequence_id = ++next_sequence_id;
+        const double timestamp_s = 0.0025 * static_cast<double>(sequence_id);
+
+        const auto started_at = std::chrono::steady_clock::now();
+        static_cast<void>(coordinator.process(make_imu_measurement(sequence_id, timestamp_s)));
+        const double active_latency_us =
+            std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - started_at)
+                .count();
+        if (active_latencies) {
+            active_latencies->push_back(active_latency_us);
+        }
+        static_cast<void>(baseline.process(make_imu_measurement(sequence_id, timestamp_s)));
+
+        if ((sequence_id % 20u) == 0u) {
+            static_cast<void>(coordinator.process(
+                make_visual_measurement(sequence_id + 100000u, timestamp_s + 0.0005)));
+            static_cast<void>(baseline.process(
+                make_visual_measurement(sequence_id + 100000u, timestamp_s + 0.0005)));
+        }
+        if ((sequence_id % 50u) == 0u) {
+            static_cast<void>(coordinator.process(
+                make_depth_measurement(sequence_id + 200000u, timestamp_s + 0.0010)));
+            static_cast<void>(baseline.process(
+                make_depth_measurement(sequence_id + 200000u, timestamp_s + 0.0010)));
+        }
+
+        if (shadow_latencies && delayed_shadow) {
+            shadow_latencies->push_back(delayed_shadow->last_processing_latency_us());
+        }
+
+        if (config.throttle_queue_depth > 0) {
+            while (coordinator.telemetry().queue_depth > config.throttle_queue_depth) {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+        }
+
+        if (config.wait_for_shadow_idle_each_iteration && delayed_shadow &&
+            !coordinator.wait_for_shadow_idle(std::chrono::milliseconds(5000))) {
+            throw std::runtime_error("shadow benchmark pacing wait timed out");
+        }
+    }
+}
+
+BenchmarkScenarioResult run_scenario(const BenchmarkScenarioConfig& config, bool emit_samples) {
+    BenchmarkScenarioResult result;
+    result.config = config;
+    const auto scenario_started_at = std::chrono::steady_clock::now();
+
+    try {
+        auto active = std::make_shared<MinimalEskfAdapter>();
+        EstimatorCoordinator coordinator(std::static_pointer_cast<StateEstimator>(active));
+        coordinator.reset({});
+
+        std::shared_ptr<DelayedShadowEstimator> delayed_shadow;
+        if (scenario_uses_shadow(config.mode)) {
+            ShadowEstimatorConfig shadow_config;
+            shadow_config.enabled = true;
+            shadow_config.max_queue_depth = config.queue_depth;
+            shadow_config.max_lag_ms = config.max_lag_ms;
+
+            auto owned_shadow = std::make_unique<DelayedShadowEstimator>(vio::EKFConfig{},
+                                                                         config.shadow_delay);
+            owned_shadow->set_validation_config(vio::EstimatorValidationConfig{});
+            delayed_shadow = std::shared_ptr<DelayedShadowEstimator>(owned_shadow.get(),
+                                                                     [](DelayedShadowEstimator*) {});
+            coordinator.configure_shadow(std::move(shadow_config), std::move(owned_shadow));
+        }
+
+        MinimalEskfAdapter baseline;
+        baseline.reset({});
+
+        uint64_t next_sequence_id = 0;
+
+        const auto warmup_started_at = std::chrono::steady_clock::now();
+        process_iteration_batch(coordinator, baseline, delayed_shadow, next_sequence_id,
+                                config.warmup_iteration_count, nullptr, nullptr, config);
+        result.warmup_duration_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
+                                                      warmup_started_at)
+                .count();
+
+        std::vector<double> active_latencies;
+        std::vector<double> shadow_processing_latencies;
+        active_latencies.reserve(config.measured_iteration_count);
+        shadow_processing_latencies.reserve(config.measured_iteration_count);
+
+        const auto measured_started_at = std::chrono::steady_clock::now();
+        process_iteration_batch(coordinator, baseline, delayed_shadow, next_sequence_id,
+                                config.measured_iteration_count, &active_latencies,
+                                scenario_uses_shadow(config.mode) ? &shadow_processing_latencies
+                                                                  : nullptr,
+                                config);
+        result.measured_duration_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
+                                                      measured_started_at)
+                .count();
+
+        if (scenario_uses_shadow(config.mode) &&
+            !coordinator.wait_for_shadow_idle(std::chrono::milliseconds(10000))) {
+            throw std::runtime_error("shadow benchmark did not drain");
+        }
+
+        result.active_process_latency = compute_stats(active_latencies);
+        result.shadow_processing_latency = compute_stats(shadow_processing_latencies);
+        result.active_output_matches_baseline = coordinator.active_snapshot().pose.position.isApprox(
+            baseline.snapshot().pose.position, 1e-9);
+
+        const auto telemetry = coordinator.telemetry();
+        result.shadow_queue_high_water_mark = telemetry.queue_high_water_mark;
+        result.shadow_dropped_event_count = telemetry.dropped_events;
+        result.shadow_lag_ms = telemetry.lag_ms;
+        result.shadow_health = shadow_health_to_string(telemetry.shadow_health);
+
+        const auto shutdown_started_at = std::chrono::steady_clock::now();
+        coordinator.stop_shadow();
+        result.shutdown_time_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
+                                                      shutdown_started_at)
+                .count();
+        result.total_duration_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
+                                                      scenario_started_at)
+                .count();
+
+        if (emit_samples) {
+            result.active_process_samples_us = std::move(active_latencies);
+            result.shadow_processing_samples_us = std::move(shadow_processing_latencies);
+        }
+        result.success = true;
+    } catch (const std::exception& ex) {
+        result.failure_reason = ex.what();
+        result.total_duration_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() -
+                                                      scenario_started_at)
+                .count();
+    }
+
+    return result;
+}
+
+json stats_to_json(const LatencyStats& stats) {
+    return json{{"mean", stats.mean_us},
+                {"median", stats.median_us},
+                {"p95", stats.p95_us},
+                {"p99", stats.p99_us},
+                {"min", stats.min_us},
+                {"max", stats.max_us},
+                {"stddev", stats.stddev_us},
+                {"sample_count", stats.sample_count}};
+}
+
+json scenario_config_to_json(const BenchmarkScenarioConfig& config) {
+    return json{{"mode", config.mode},
+                {"warmup_iteration_count", config.warmup_iteration_count},
+                {"measured_iteration_count", config.measured_iteration_count},
+                {"shadow_delay_ms", config.shadow_delay.count()},
+                {"queue_depth", config.queue_depth},
+                {"max_lag_ms", config.max_lag_ms},
+                {"throttle_queue_depth", config.throttle_queue_depth},
+                {"wait_for_shadow_idle_each_iteration",
+                 config.wait_for_shadow_idle_each_iteration}};
+}
+
+json scenario_to_json(const BenchmarkScenarioResult& scenario, bool emit_samples) {
+    json output{{"config", scenario_config_to_json(scenario.config)},
+                {"success", scenario.success},
+                {"failure_reason", scenario.failure_reason},
+                {"active_process_latency_us", stats_to_json(scenario.active_process_latency)},
+                {"shadow_processing_latency_us", stats_to_json(scenario.shadow_processing_latency)},
+                {"queue_push_latency_us", nullptr},
+                {"active_path_regression_percent", scenario.active_path_regression_percent},
+                {"shadow_queue_high_water_mark", scenario.shadow_queue_high_water_mark},
+                {"shadow_dropped_event_count", scenario.shadow_dropped_event_count},
+                {"shadow_lag_ms", scenario.shadow_lag_ms},
+                {"shadow_health", scenario.shadow_health},
+                {"shutdown_time_ms", scenario.shutdown_time_ms},
+                {"active_output_matches_baseline", scenario.active_output_matches_baseline},
+                {"warmup_duration_ms", scenario.warmup_duration_ms},
+                {"measured_duration_ms", scenario.measured_duration_ms},
+                {"total_duration_ms", scenario.total_duration_ms}};
+    if (emit_samples) {
+        output["active_process_samples_us"] = scenario.active_process_samples_us;
+        output["shadow_processing_samples_us"] = scenario.shadow_processing_samples_us;
+    }
+    return output;
+}
+
+BenchmarkCliOptions parse_cli_options(int argc, char** argv) {
+    BenchmarkCliOptions options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view arg = argv[i];
+        if (arg == "--output" && i + 1 < argc) {
+            options.output_path = std::filesystem::path(argv[++i]);
+        } else if (arg == "--scenario" && i + 1 < argc) {
+            options.scenario = argv[++i];
+        } else if (arg == "--iterations" && i + 1 < argc) {
+            options.measured_iteration_count = static_cast<size_t>(std::stoull(argv[++i]));
+        } else if (arg == "--warmup-iterations" && i + 1 < argc) {
+            options.warmup_iteration_count = static_cast<size_t>(std::stoull(argv[++i]));
+        } else if (arg == "--emit-samples") {
+            options.emit_samples = true;
+        } else {
+            throw std::runtime_error("unsupported benchmark argument");
+        }
+    }
+    return options;
+}
+
+std::vector<BenchmarkScenarioConfig> scenario_configs_from_options(
+    const BenchmarkCliOptions& options) {
+    const auto make_active_only = [&options]() {
+        return BenchmarkScenarioConfig{"active_only", options.warmup_iteration_count,
+                                       options.measured_iteration_count, std::chrono::milliseconds(0),
+                                       512, 100.0, 0, false};
+    };
+    const auto make_active_with_shadow = [&options]() {
+        return BenchmarkScenarioConfig{"active_with_shadow", options.warmup_iteration_count,
+                                       options.measured_iteration_count, std::chrono::milliseconds(0),
+                                       512, 100.0, 0, true};
+    };
+    const auto make_shadow_overload = [&options]() {
+        return BenchmarkScenarioConfig{"shadow_overload", options.warmup_iteration_count,
+                                       options.measured_iteration_count, std::chrono::milliseconds(2), 8,
+                                       0.5, 0, false};
+    };
+
+    if (options.scenario == "all") {
+        return {make_active_only(), make_active_with_shadow(), make_shadow_overload()};
+    }
+    if (options.scenario == "active_only") {
+        return {make_active_only()};
+    }
+    if (options.scenario == "active_with_shadow") {
+        return {make_active_with_shadow()};
+    }
+    if (options.scenario == "shadow_overload") {
+        return {make_shadow_overload()};
+    }
+    throw std::runtime_error("unsupported benchmark scenario");
+}
+
+} // namespace
+} // namespace drone::estimation
+
+int main(int argc, char** argv) {
+    using namespace drone::estimation;
+
+    try {
+        const auto options = parse_cli_options(argc, argv);
+        auto configs = scenario_configs_from_options(options);
+
+        std::vector<BenchmarkScenarioResult> scenarios;
+        scenarios.reserve(configs.size());
+        for (const auto& config : configs) {
+            scenarios.push_back(run_scenario(config, options.emit_samples));
+        }
+
+        std::optional<double> active_only_mean_us;
+        for (const auto& scenario : scenarios) {
+            if (scenario.config.mode == "active_only" && scenario.success &&
+                scenario.active_process_latency.mean_us > 0.0) {
+                active_only_mean_us = scenario.active_process_latency.mean_us;
+                break;
+            }
+        }
+        if (active_only_mean_us.has_value()) {
+            for (auto& scenario : scenarios) {
+                if (scenario.config.mode != "active_only" && scenario.success) {
+                    scenario.active_path_regression_percent =
+                        ((scenario.active_process_latency.mean_us - *active_only_mean_us) /
+                         *active_only_mean_us) *
+                        100.0;
+                }
+            }
+        }
+
+        json output{{"report_schema_version", 2},
+                    {"date_utc", "2026-07-17"},
+#if defined(_WIN32)
+                    {"operating_system", "windows"},
+#elif defined(__linux__)
+                    {"operating_system", "linux"},
+#else
+                    {"operating_system", "unknown"},
+#endif
+#if defined(_MSC_VER)
+                    {"compiler", std::string("MSVC ") + std::to_string(_MSC_VER)},
+#elif defined(__clang__)
+                    {"compiler", std::string("Clang ") + __clang_version__},
+#elif defined(__GNUC__)
+                    {"compiler", std::string("GCC ") + __VERSION__},
+#else
+                    {"compiler", "unknown"},
+#endif
+#ifdef NDEBUG
+                    {"build_type", "Release"},
+#else
+                    {"build_type", "Debug"},
+#endif
+                    {"cpu_model", "not_captured_in_tool"},
+                    {"timer_source", "std::chrono::steady_clock"},
+                    {"limitations",
+                     json::array({"software benchmark only",
+                                  "does not imply hard real-time guarantees",
+                                  "does not imply flight readiness",
+                                  "queue push latency is not measured separately"})}};
+
+        output["scenarios"] = json::array();
+        bool overall_success = true;
+        for (const auto& scenario : scenarios) {
+            output["scenarios"].push_back(scenario_to_json(scenario, options.emit_samples));
+            overall_success = overall_success && scenario.success;
+        }
+        output["success"] = overall_success;
+
+        if (options.output_path.has_value()) {
+            std::ofstream out(*options.output_path, std::ios::trunc);
+            if (!out.is_open()) {
+                std::cerr << "failed to open benchmark output path" << std::endl;
+                return 1;
+            }
+            out << output.dump(2) << std::endl;
+        } else {
+            std::cout << output.dump(2) << std::endl;
+        }
+
+        return overall_success ? 0 : 1;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "builtin-baseline": "f87344cac03158cbf1467264565f1fd36b382a24",
   "dependencies": [
     "eigen3",
+    "nlohmann-json",
     "opencv4",
     "pcl",
     "spdlog"


### PR DESCRIPTION
## Summary
- add the Phase 15 estimator safety baseline and Phase 16 estimator interface/adapter architecture
- keep the minimal ESKF as the only authoritative estimator
- add bounded shadow estimator execution with explicit queue/drop/stale telemetry
- add the native C++ replay runner and repeated benchmark aggregation workflow
- close local validation evidence across MSVC, GCC, Clang, GCC ASan/UBSan, Clang ASan/UBSan, and estimator-only TSan

## Safety invariants
- minimal ESKF remains authoritative
- shadow remains disabled by default
- shadow cannot publish authoritative navigation state
- active output remains unchanged by shadow execution
- active processing does not wait for shadow processing
- bounded queueing and observable drops remain enforced
- unsupported experimental configurations fail closed

## Validation highlights
- Phase 15 estimator safety baseline documented and committed
- Phase 16 estimator interface, measurement adapters, replay, and shadow isolation tests added
- native replay active-only and active-with-identical-shadow validated locally
- repeated benchmark aggregation completed with bounded overload behavior
- estimator-only TSan lane passed without suppressions after isolating the representative validation path

## Not activated
- FEJ remains disabled
- MSCKF remains disabled
- automatic ZUPT remains disabled
- loop closure remains disabled
- no estimator switching or shadow-to-active promotion exists

## Limitations
- software validation does not imply hardware, HIL, or flight readiness
- physical HIL remains pending
- flight validation remains incomplete
- unrelated unstaged user changes are not included in this PR