### PR TITLE
Visual Feature Track Ingest

### DIFF
--- a/.github/workflows/msckf-retirement-orchestrator.yml
+++ b/.github/workflows/msckf-retirement-orchestrator.yml
@@ -1,151 +1,32 @@
-name: MSCKF Retirement Integration Orchestrator
+name: MSCKF Retirement Integrity Check
 
 on:
-  pull_request:
-    branches:
-      - phase22-final-validation
-    paths:
-      - '.github/msckf-retirement-trigger.txt'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  integrate:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+  verify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-      - name: Checkout head branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
+      - uses: actions/checkout@v7
 
-      - name: Patch production retirement boundary
+      - name: Verify integrated retirement implementation
         shell: bash
         run: |
-          python3 - <<'PY'
-          from pathlib import Path
+          set -euxo pipefail
+          test -f include/vio/MsckfMarginalization.hpp
+          test -f include/vio/MsckfRetirementTransaction.hpp
+          test -f tests/test_msckf_marginalization_integration.cpp
+          grep -q 'marginalization_attempts' include/vio/EKFEstimator.hpp
+          grep -q 'MsckfMarginalization' src/vio/Phase17ESKFEstimator.cpp
+          grep -q 'MsckfRetirementTransaction' src/vio/Phase17ESKFEstimator.cpp
+          grep -q 'test_msckf_marginalization_integration' tests/CMakeLists.txt
 
-          def replace_once(text, old, new, label):
-              count = text.count(old)
-              if count != 1:
-                  raise SystemExit(f"{label}: expected exactly one match, found {count}")
-              return text.replace(old, new, 1)
-
-          p = Path('include/vio/EKFEstimator.hpp')
-          s = p.read_text(encoding='utf-8-sig')
-          old = '''    uint64_t msckf_deterministic_evictions{0};\n    uint64_t triangulation_attempts{0};'''
-          new = '''    uint64_t msckf_deterministic_evictions{0};\n    uint64_t marginalization_attempts{0};\n    uint64_t marginalizations_completed{0};\n    uint64_t marginalization_failures{0};\n    uint64_t marginalization_retiring_state_id{0};\n    uint64_t marginalization_affected_tracks{0};\n    uint64_t marginalization_constraint_candidates{0};\n    uint64_t marginalization_covariance_dim_before{0};\n    uint64_t marginalization_covariance_dim_after{0};\n    uint64_t marginalization_stale_references{0};\n    double marginalization_covariance_symmetry_error{0.0};\n    double marginalization_covariance_min_eigenvalue{0.0};\n    uint64_t triangulation_attempts{0};'''
-          if old in s:
-              s = replace_once(s, old, new, 'EKFDiagnostics fields')
-              p.write_text(s, encoding='utf-8')
-
-          p = Path('include/vio/StateEstimator.hpp')
-          s = p.read_text()
-          old = '''    uint64_t msckf_deterministic_evictions{0};\n    uint64_t triangulation_attempts{0};'''
-          new = '''    uint64_t msckf_deterministic_evictions{0};\n    uint64_t marginalization_attempts{0};\n    uint64_t marginalizations_completed{0};\n    uint64_t marginalization_failures{0};\n    uint64_t marginalization_retiring_state_id{0};\n    uint64_t marginalization_affected_tracks{0};\n    uint64_t marginalization_constraint_candidates{0};\n    uint64_t marginalization_covariance_dim_before{0};\n    uint64_t marginalization_covariance_dim_after{0};\n    uint64_t marginalization_stale_references{0};\n    double marginalization_covariance_symmetry_error{0.0};\n    double marginalization_covariance_min_eigenvalue{0.0};\n    uint64_t triangulation_attempts{0};'''
-          if old in s:
-              s = replace_once(s, old, new, 'EstimatorStateSnapshot fields')
-              p.write_text(s)
-
-          p = Path('src/vio/Phase17ESKFEstimator.cpp')
-          s = p.read_text()
-          old = '#include "vio/Phase17ESKFEstimator.hpp"\n\n#include "vio/MeasurementEnvelope.hpp"'
-          if '#include "vio/MsckfMarginalization.hpp"' not in s:
-              new = '#include "vio/Phase17ESKFEstimator.hpp"\n\n#include "vio/MeasurementEnvelope.hpp"\n#include "vio/MsckfMarginalization.hpp"\n#include "vio/MsckfRetirementTransaction.hpp"'
-              s = replace_once(s, old, new, 'marginalization includes')
-
-          old = '''    diagnostics_.msckf_oldest_state_age_s = 0.0;\n    diagnostics_.msckf_deterministic_evictions = 0;\n}'''
-          if 'diagnostics_.marginalization_attempts = 0;' not in s:
-              new = '''    diagnostics_.msckf_oldest_state_age_s = 0.0;\n    diagnostics_.msckf_deterministic_evictions = 0;\n    diagnostics_.marginalization_attempts = 0;\n    diagnostics_.marginalizations_completed = 0;\n    diagnostics_.marginalization_failures = 0;\n    diagnostics_.marginalization_retiring_state_id = 0;\n    diagnostics_.marginalization_affected_tracks = 0;\n    diagnostics_.marginalization_constraint_candidates = 0;\n    diagnostics_.marginalization_covariance_dim_before = 0;\n    diagnostics_.marginalization_covariance_dim_after = 0;\n    diagnostics_.marginalization_stale_references = 0;\n    diagnostics_.marginalization_covariance_symmetry_error = 0.0;\n    diagnostics_.marginalization_covariance_min_eigenvalue = 0.0;\n}'''
-              s = replace_once(s, old, new, 'clear marginalization diagnostics')
-
-          old = '''void Phase17ESKFEstimator::evict_msckf_state_locked() {\n    if (msckf_state_order_.empty()) {\n        refresh_msckf_oldest_state_age_locked();\n        return;\n    }\n    const uint64_t oldest_id = msckf_state_order_.front();\n    msckf_state_order_.pop_front();\n    if (const auto it = msckf_camera_states_.find(oldest_id); it != msckf_camera_states_.end()) {\n        remove_clone_covariance_block_locked(oldest_id);\n        msckf_timestamp_to_state_id_.erase(it->second.timestamp_key);\n        prune_feature_tracks_for_state_locked(oldest_id);\n        msckf_camera_states_.erase(it);\n        if (msckf_diagnostics_enabled_locked()) {\n            ++diagnostics_.msckf_states_removed;\n            ++diagnostics_.msckf_deterministic_evictions;\n        }\n    }\n    refresh_msckf_oldest_state_age_locked();\n}'''
-          if old in s:
-              new = '''void Phase17ESKFEstimator::evict_msckf_state_locked() {\n    if (msckf_state_order_.empty()) {\n        refresh_msckf_oldest_state_age_locked();\n        return;\n    }\n\n    const uint64_t oldest_id = msckf_state_order_.front();\n    const auto state_it = msckf_camera_states_.find(oldest_id);\n    if (state_it == msckf_camera_states_.end()) {\n        if (msckf_diagnostics_enabled_locked()) { ++diagnostics_.marginalization_failures; }\n        note_rejection_locked(EstimatorOperationResult::FailedNumericalValidation);\n        return;\n    }\n\n    std::vector<MarginalizationTrackSummary> summaries;\n    summaries.reserve(feature_tracks_.size());\n    for (const auto& [key, track] : feature_tracks_) {\n        (void)key;\n        MarginalizationTrackSummary summary;\n        summary.track_id = track.track_id;\n        summary.landmark_initialized = track.landmark_initialized;\n        for (const auto& observation : track.observations) {\n            summary.observation_state_ids.push_back(observation.state_id);\n        }\n        summaries.push_back(std::move(summary));\n    }\n    const auto plan = MsckfMarginalization::build_plan(\n        oldest_id, summaries, msckf_cfg_.update.minimum_track_length);\n    const std::vector<uint64_t> ordered_clone_ids(msckf_state_order_.begin(), msckf_state_order_.end());\n\n    MsckfRetirementRequest request;\n    request.retiring_state_id = oldest_id;\n    request.base_error_dim = static_cast<std::size_t>(AugmentedStateLayout::kBaseErrorDim);\n    request.clone_error_dim = static_cast<std::size_t>(AugmentedStateLayout::kCloneErrorDim);\n    request.symmetry_tolerance = validation_cfg_.covariance_symmetry_tolerance;\n    request.negativity_tolerance = validation_cfg_.variance_negativity_tolerance;\n\n    if (msckf_diagnostics_enabled_locked()) {\n        ++diagnostics_.marginalization_attempts;\n        diagnostics_.marginalization_retiring_state_id = oldest_id;\n        diagnostics_.marginalization_affected_tracks = plan.affected_track_ids.size();\n        diagnostics_.marginalization_constraint_candidates = plan.constraint_candidate_track_ids.size();\n        diagnostics_.marginalization_covariance_dim_before = static_cast<uint64_t>(augmented_covariance_.rows());\n    }\n\n    const auto prepared = MsckfRetirementTransaction::prepare(\n        request, ordered_clone_ids, augmented_covariance_);\n    if (!prepared || !prepared->committed) {\n        if (msckf_diagnostics_enabled_locked()) { ++diagnostics_.marginalization_failures; }\n        note_rejection_locked(EstimatorOperationResult::FailedNumericalValidation);\n        return;\n    }\n\n    // Build candidate metadata first so failure cannot publish partial retirement.\n    auto candidate_order = msckf_state_order_;\n    auto candidate_states = msckf_camera_states_;\n    auto candidate_timestamp_map = msckf_timestamp_to_state_id_;\n    auto candidate_tracks = feature_tracks_;\n    candidate_order.pop_front();\n    candidate_timestamp_map.erase(state_it->second.timestamp_key);\n    candidate_states.erase(oldest_id);\n    for (auto track_it = candidate_tracks.begin(); track_it != candidate_tracks.end();) {\n        auto& observations = track_it->second.observations;\n        observations.erase(std::remove_if(observations.begin(), observations.end(),\n                                          [oldest_id](const FeatureObservation& observation) {\n                                              return observation.state_id == oldest_id;\n                                          }),\n                           observations.end());\n        if (observations.empty()) {\n            track_it = candidate_tracks.erase(track_it);\n        } else {\n            ++track_it;\n        }\n    }\n\n    uint64_t stale_references = 0;\n    for (const auto& [key, track] : candidate_tracks) {\n        (void)key;\n        stale_references += static_cast<uint64_t>(std::count_if(\n            track.observations.begin(), track.observations.end(),\n            [oldest_id](const FeatureObservation& observation) { return observation.state_id == oldest_id; }));\n    }\n    const auto health = MsckfMarginalization::covariance_health(\n        prepared->retained_covariance, validation_cfg_.covariance_symmetry_tolerance,\n        validation_cfg_.variance_negativity_tolerance);\n    const std::size_t expected_dim = static_cast<std::size_t>(kErrorDim) +\n        candidate_order.size() * static_cast<std::size_t>(AugmentedStateLayout::kCloneErrorDim);\n    if (!health.finite || !health.symmetric || !health.psd_within_tolerance ||\n        prepared->retained_covariance.rows() != static_cast<Eigen::Index>(expected_dim) ||\n        stale_references != 0u) {\n        if (msckf_diagnostics_enabled_locked()) { ++diagnostics_.marginalization_failures; }\n        note_rejection_locked(EstimatorOperationResult::FailedNumericalValidation);\n        return;\n    }\n\n    // Atomic commit boundary.\n    const uint64_t removed_track_count = static_cast<uint64_t>(feature_tracks_.size() - candidate_tracks.size());\n    msckf_state_order_ = std::move(candidate_order);\n    msckf_camera_states_ = std::move(candidate_states);\n    msckf_timestamp_to_state_id_ = std::move(candidate_timestamp_map);\n    feature_tracks_ = std::move(candidate_tracks);\n    augmented_covariance_ = prepared->retained_covariance;\n    P_ = 0.5 * (augmented_covariance_.block(0, 0, kErrorDim, kErrorDim) +\n                augmented_covariance_.block(0, 0, kErrorDim, kErrorDim).transpose());\n\n    if (msckf_diagnostics_enabled_locked()) {\n        ++diagnostics_.marginalizations_completed;\n        ++diagnostics_.msckf_states_removed;\n        ++diagnostics_.msckf_deterministic_evictions;\n        diagnostics_.feature_tracks_removed += removed_track_count;\n        diagnostics_.marginalization_covariance_dim_after = static_cast<uint64_t>(augmented_covariance_.rows());\n        diagnostics_.marginalization_stale_references = stale_references;\n        diagnostics_.marginalization_covariance_symmetry_error = health.symmetry_error;\n        diagnostics_.marginalization_covariance_min_eigenvalue = health.minimum_eigenvalue;\n    }\n    refresh_triangulation_diagnostics_locked();\n    refresh_msckf_oldest_state_age_locked();\n}'''
-              s = replace_once(s, old, new, 'production eviction boundary')
-
-          old = '''    while (msckf_state_order_.size() > msckf_cfg_.max_camera_states) {\n        evict_msckf_state_locked();\n    }\n    refresh_msckf_oldest_state_age_locked();\n    return state.state_id;'''
-          if old in s:
-              s = replace_once(s, old, '''    refresh_msckf_oldest_state_age_locked();\n    return state.state_id;''', 'defer capture retirement')
-
-          old = '''void Phase17ESKFEstimator::maybe_capture_msckf_camera_state_locked(double capture_timestamp_s) {\n    (void)capture_or_get_msckf_camera_state_locked(capture_timestamp_s);\n}'''
-          if old in s:
-              new = '''void Phase17ESKFEstimator::maybe_capture_msckf_camera_state_locked(double capture_timestamp_s) {\n    (void)capture_or_get_msckf_camera_state_locked(capture_timestamp_s);\n    while (msckf_state_order_.size() > msckf_cfg_.max_camera_states) {\n        const auto before = msckf_state_order_.size();\n        evict_msckf_state_locked();\n        if (msckf_state_order_.size() >= before) { break; }\n    }\n}'''
-              s = replace_once(s, old, new, 'non-vision retirement')
-
-          old = '''            try_initialize_triangulated_landmarks_locked(K);\n            try_apply_msckf_feature_updates_locked(K, state_id);\n        }\n    }'''
-          if old in s:
-              new = '''            try_initialize_triangulated_landmarks_locked(K);\n            try_apply_msckf_feature_updates_locked(K, state_id);\n            while (msckf_state_order_.size() > msckf_cfg_.max_camera_states) {\n                const auto before = msckf_state_order_.size();\n                evict_msckf_state_locked();\n                if (msckf_state_order_.size() >= before) { break; }\n            }\n        }\n    }'''
-              s = replace_once(s, old, new, 'vision post-constraint retirement')
-
-          old = '''    out.msckf_deterministic_evictions = diag.msckf_deterministic_evictions;\n    out.triangulation_attempts = diag.triangulation_attempts;'''
-          if old in s:
-              new = '''    out.msckf_deterministic_evictions = diag.msckf_deterministic_evictions;\n    out.marginalization_attempts = diag.marginalization_attempts;\n    out.marginalizations_completed = diag.marginalizations_completed;\n    out.marginalization_failures = diag.marginalization_failures;\n    out.marginalization_retiring_state_id = diag.marginalization_retiring_state_id;\n    out.marginalization_affected_tracks = diag.marginalization_affected_tracks;\n    out.marginalization_constraint_candidates = diag.marginalization_constraint_candidates;\n    out.marginalization_covariance_dim_before = diag.marginalization_covariance_dim_before;\n    out.marginalization_covariance_dim_after = diag.marginalization_covariance_dim_after;\n    out.marginalization_stale_references = diag.marginalization_stale_references;\n    out.marginalization_covariance_symmetry_error = diag.marginalization_covariance_symmetry_error;\n    out.marginalization_covariance_min_eigenvalue = diag.marginalization_covariance_min_eigenvalue;\n    out.triangulation_attempts = diag.triangulation_attempts;'''
-              s = replace_once(s, old, new, 'snapshot diagnostics')
-          p.write_text(s)
-
-          p = Path('tests/CMakeLists.txt')
-          s = p.read_text()
-          anchor = 'drone_register_gtest(test_phase22_msckf_update "unit;navigation;replay;phase22")\n'
-          if 'test_msckf_marginalization_integration' not in s:
-              addition = anchor + '''\nadd_executable(test_msckf_marginalization_integration test_msckf_marginalization_integration.cpp)\ntarget_link_libraries(test_msckf_marginalization_integration PRIVATE\n    drone_test_support\n    ${DRONE_PHASE17_TEST_CORE}\n    Eigen3::Eigen\n)\ndrone_register_gtest(test_msckf_marginalization_integration "unit;navigation;replay;marginalization")\n'''
-              s = replace_once(s, anchor, addition, 'integration test target')
-              p.write_text(s)
-
-          test = Path('tests/test_msckf_marginalization_integration.cpp')
-          if not test.exists():
-              test.write_text(r'''#include "vio/Phase17ESKFEstimator.hpp"
-#include <gtest/gtest.h>
-
-namespace drone::vio { namespace {
-MsckfConfig config(bool diagnostics = true) {
-    MsckfConfig cfg; cfg.enabled = true; cfg.max_camera_states = 2;
-    cfg.diagnostics_enabled = diagnostics; cfg.triangulation.enabled = false; cfg.update.enabled = false;
-    return cfg;
-}
-void drive(Phase17ESKFEstimator& estimator) {
-    ASSERT_EQ(estimator.process_imu_measurement({0.0,0.0,9.81}, Eigen::Vector3d::Zero(), 0.0), EstimatorOperationResult::Accepted);
-    for (int i=1;i<=3;++i) {
-        const double t=0.01*static_cast<double>(i);
-        ASSERT_EQ(estimator.process_imu_measurement({0.0,0.0,9.81}, Eigen::Vector3d::Zero(), t), EstimatorOperationResult::Accepted);
-        const auto pose=estimator.state(); estimator.update_visual_pose(pose.position, pose.velocity, 0.35, 0.45);
-    }
-}
-TEST(MsckfMarginalizationIntegration, TransactionalOldestRetirementKeepsWindowBounded) {
-    Phase17ESKFEstimator e; e.reset(); e.configure_msckf(config()); drive(e);
-    EXPECT_EQ(e.msckf_state_ids_for_test(), (std::vector<uint64_t>{2u,3u}));
-    const auto P=e.augmented_covariance_for_test(); EXPECT_EQ(P.rows(),27); EXPECT_TRUE(P.array().isFinite().all());
-    const auto d=e.diagnostics(); EXPECT_EQ(d.marginalization_attempts,1u); EXPECT_EQ(d.marginalizations_completed,1u);
-    EXPECT_EQ(d.marginalization_failures,0u); EXPECT_EQ(d.marginalization_stale_references,0u);
-    EXPECT_EQ(d.marginalization_covariance_dim_before,33u); EXPECT_EQ(d.marginalization_covariance_dim_after,27u);
-}
-TEST(MsckfMarginalizationIntegration, DiagnosticsDisabledStillRetires) {
-    Phase17ESKFEstimator e; e.reset(); e.configure_msckf(config(false)); drive(e);
-    EXPECT_EQ(e.msckf_state_ids_for_test(), (std::vector<uint64_t>{2u,3u})); EXPECT_EQ(e.augmented_covariance_for_test().rows(),27);
-    EXPECT_EQ(e.diagnostics().marginalization_attempts,0u);
-}
-} }
-''')
-          PY
-
-      - name: Install focused dependencies
+      - name: Report
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libeigen3-dev libspdlog-dev libfmt-dev libboost-all-dev
-
-      - name: Syntax-check integration
-        run: |
-          g++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -fsyntax-only -Iinclude -Ithird_party/crypto -I/usr/include/eigen3 src/vio/Phase17ESKFEstimator.cpp
-          clang++ -std=c++20 -Wall -Wextra -Wpedantic -Werror -fsyntax-only -Iinclude -Ithird_party/crypto -I/usr/include/eigen3 src/vio/Phase17ESKFEstimator.cpp
-
-      - name: Commit to PR head
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add include/vio/EKFEstimator.hpp include/vio/StateEstimator.hpp src/vio/Phase17ESKFEstimator.cpp tests/CMakeLists.txt tests/test_msckf_marginalization_integration.cpp
-          if git diff --cached --quiet; then exit 0; fi
-          git commit -m "Wire MSCKF marginalization retirement boundary"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          echo 'MSCKF camera-state retirement is integrated in source.'
+          echo 'This workflow is validation-only and does not mutate branches.'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,3 +259,34 @@ install(EXPORT DroneSwarmTargets
     NAMESPACE DroneSwarm::
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
+
+install(FILES
+    "${PROJECT_BINARY_DIR}/DroneSwarmSensorFusionConfig.cmake"
+    "${PROJECT_BINARY_DIR}/DroneSwarmSensorFusionConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+if(DRONE_ENABLE_CPACK)
+    set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+    set(CPACK_PACKAGE_VENDOR "Md Shahanur Islam Shagor")
+    set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+    set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+    set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
+    if(WIN32)
+        set(CPACK_GENERATOR "ZIP")
+    else()
+        set(CPACK_GENERATOR "TGZ")
+    endif()
+    include(CPack)
+endif()
+
+message(STATUS "")
+message(STATUS "DroneSwarmSensorFusion configuration summary")
+message(STATUS "  Build type          : ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Compiler            : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "  Tests               : ${DRONE_BUILD_TESTS}")
+message(STATUS "  Python bindings     : ${DRONE_PYTHON_BINDINGS_STATUS}")
+message(STATUS "  Fast-DDS transport  : ${DRONE_FASTDDS_STATUS}")
+message(STATUS "  TensorRT inference  : ${DRONE_TENSORRT_STATUS}")
+message(STATUS "  Install prefix      : ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if(DRONE_BUILD_TESTS)
     drone_enable_googletest()
     enable_testing()
     add_subdirectory(tests)
+    include("${PROJECT_SOURCE_DIR}/tests/visual_feature_track_ingest.cmake")
 endif()
 
 install(TARGETS drone_node sensor_fusion_core
@@ -258,34 +259,3 @@ install(EXPORT DroneSwarmTargets
     NAMESPACE DroneSwarm::
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
-
-install(FILES
-    "${PROJECT_BINARY_DIR}/DroneSwarmSensorFusionConfig.cmake"
-    "${PROJECT_BINARY_DIR}/DroneSwarmSensorFusionConfigVersion.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
-
-if(DRONE_ENABLE_CPACK)
-    set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
-    set(CPACK_PACKAGE_VENDOR "Md Shahanur Islam Shagor")
-    set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
-    set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
-    set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
-    if(WIN32)
-        set(CPACK_GENERATOR "ZIP")
-    else()
-        set(CPACK_GENERATOR "TGZ")
-    endif()
-    include(CPack)
-endif()
-
-message(STATUS "")
-message(STATUS "DroneSwarmSensorFusion configuration summary")
-message(STATUS "  Build type          : ${CMAKE_BUILD_TYPE}")
-message(STATUS "  Compiler            : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "  Tests               : ${DRONE_BUILD_TESTS}")
-message(STATUS "  Python bindings     : ${DRONE_PYTHON_BINDINGS_STATUS}")
-message(STATUS "  Fast-DDS transport  : ${DRONE_FASTDDS_STATUS}")
-message(STATUS "  TensorRT inference  : ${DRONE_TENSORRT_STATUS}")
-message(STATUS "  Install prefix      : ${CMAKE_INSTALL_PREFIX}")
-message(STATUS "")

--- a/include/vio/VIOPipeline.hpp
+++ b/include/vio/VIOPipeline.hpp
@@ -4,21 +4,19 @@
 
 #pragma once
 
-// VIOPipeline.hpp    Visual-Inertial Odometry orchestrator
-// Manages the EKF, feature tracking, and multi-sensor data flow
-// Drone Swarm Sensor Fusion  |  Phase 2
-
+#include "runtime/RuntimeMode.hpp"
+#include "sensors/CameraSensor.hpp"
+#include "sensors/IMUSensor.hpp"
+#include "sensors/LidarSensor.hpp"
 #include "vio/EKFEstimator.hpp"
 #include "vio/EstimatorCoordinator.hpp"
-#include "sensors/IMUSensor.hpp"
-#include "sensors/CameraSensor.hpp"
-#include "sensors/LidarSensor.hpp"
-#include "runtime/RuntimeMode.hpp"
+#include "vio/VisualFeatureTrackManager.hpp"
 
 #include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <opencv2/core.hpp>
 #include <queue>
 #include <string>
@@ -28,7 +26,6 @@
 
 namespace drone::vio {
 
-//  Variant message for sensor event queue
 using SensorEvent =
     std::variant<sensors::ImuMeasurement, sensors::CameraFrame, sensors::LidarMeasurement>;
 
@@ -89,6 +86,10 @@ struct RuntimeTelemetry {
     double visual_update_confidence{0.0};
     bool visual_frontend_valid{false};
     bool visual_placeholder_active{false};
+    uint64_t persistent_feature_tracks{0};
+    uint64_t initialized_feature_tracks{0};
+    uint64_t rejected_feature_geometry{0};
+    uint64_t shadow_feature_batches_submitted{0};
     std::string active_estimator_name{"ekf_active"};
     std::string shadow_estimator_name{"ekf_shadow"};
     std::string active_estimator_health{"uninitialized"};
@@ -119,6 +120,8 @@ struct VisualFrontendResult {
     Eigen::Vector3d observed_position{Eigen::Vector3d::Zero()};
     Eigen::Vector3d observed_velocity{Eigen::Vector3d::Zero()};
     Eigen::Quaterniond relative_orientation{Eigen::Quaterniond::Identity()};
+    std::vector<Eigen::Vector2d> previous_inlier_pixels{};
+    std::vector<Eigen::Vector2d> current_inlier_pixels{};
     VisualFrontendMetrics metrics{};
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -139,27 +142,19 @@ public:
     using PoseCallback = std::function<void(const PoseEstimate&)>;
 
     explicit VIOPipeline(EKFConfig cfg = EKFConfig{});
+    ~VIOPipeline() { stop(); }
 
-    ~VIOPipeline() {
-        stop();
-    }
-
-    //  Sensor registration
     void attach_imu(std::shared_ptr<sensors::IMUSensor> imu);
     void attach_camera(std::shared_ptr<sensors::CameraSensor> cam);
     void attach_lidar(std::shared_ptr<sensors::LidarSensor> lidar);
 
-    //  Pipeline control
     bool start();
     void stop();
     void reset();
-    void set_runtime_mode(drone::runtime::RuntimeMode mode) {
-        runtime_mode_ = mode;
-    }
+    void set_runtime_mode(drone::runtime::RuntimeMode mode) { runtime_mode_ = mode; }
     void set_estimator_validation_config(const EstimatorValidationConfig& cfg);
     void set_shadow_msckf_config(const MsckfConfig& cfg);
 
-    //  State query â”€
     [[nodiscard]] PoseEstimate current_pose() const;
     [[nodiscard]] double drift_m() const;
     [[nodiscard]] RuntimeTelemetry runtime_telemetry() const {
@@ -167,15 +162,8 @@ public:
         return runtime_telemetry_;
     }
 
-    //  Output callback
-    void set_pose_callback(PoseCallback cb) {
-        pose_cb_ = std::move(cb);
-    }
-
-    //  Configuration
-    void set_camera_matrix(const Eigen::Matrix3d& K) {
-        K_ = K;
-    }
+    void set_pose_callback(PoseCallback cb) { pose_cb_ = std::move(cb); }
+    void set_camera_matrix(const Eigen::Matrix3d& K) { K_ = K; }
     void set_runtime_telemetry(RuntimeTelemetry telemetry) {
         std::lock_guard lock(runtime_mutex_);
         telemetry.tracked_feature_count = runtime_telemetry_.tracked_feature_count;
@@ -184,6 +172,11 @@ public:
         telemetry.visual_update_confidence = runtime_telemetry_.visual_update_confidence;
         telemetry.visual_frontend_valid = runtime_telemetry_.visual_frontend_valid;
         telemetry.visual_placeholder_active = runtime_telemetry_.visual_placeholder_active;
+        telemetry.persistent_feature_tracks = runtime_telemetry_.persistent_feature_tracks;
+        telemetry.initialized_feature_tracks = runtime_telemetry_.initialized_feature_tracks;
+        telemetry.rejected_feature_geometry = runtime_telemetry_.rejected_feature_geometry;
+        telemetry.shadow_feature_batches_submitted =
+            runtime_telemetry_.shadow_feature_batches_submitted;
         runtime_telemetry_ = std::move(telemetry);
     }
 
@@ -192,28 +185,26 @@ public:
 private:
     void enqueue(SensorEvent evt);
     void processing_loop();
-
     void handle(const sensors::ImuMeasurement& imu);
     void handle(const sensors::CameraFrame& frame);
     void handle(const sensors::LidarMeasurement&);
     void reconfigure_coordinator();
     void apply_visual_quality_to_pose(PoseEstimate& pose) const;
     void refresh_runtime_telemetry_from_coordinator();
+    void submit_tracked_features_to_shadow(const VisualFrontendResult& frontend_result,
+                                           const PoseEstimate& previous_pose,
+                                           const PoseEstimate& current_pose, double timestamp_s);
 
     std::unique_ptr<EstimatorCoordinator> coordinator_;
     EKFConfig ekf_cfg_{};
-
     std::shared_ptr<sensors::IMUSensor> imu_;
     std::shared_ptr<sensors::CameraSensor> cam_;
     std::shared_ptr<sensors::LidarSensor> lidar_;
-
-    // Thread-safe event queue
     std::queue<SensorEvent> event_queue_;
     mutable std::mutex queue_mutex_;
     std::condition_variable queue_cv_;
     std::thread proc_thread_;
     std::atomic<bool> running_{false};
-
     Eigen::Matrix3d K_{Eigen::Matrix3d::Identity()};
     PoseCallback pose_cb_;
     double last_imu_ts_{-1.0};
@@ -222,6 +213,7 @@ private:
     cv::Mat previous_gray_frame_;
     PoseEstimate previous_camera_pose_{};
     bool previous_camera_pose_valid_{false};
+    VisualFeatureTrackManager visual_feature_tracks_{};
     drone::runtime::RuntimeMode runtime_mode_{drone::runtime::RuntimeMode::SIMULATION};
     EstimatorValidationConfig estimator_validation_cfg_{};
     MsckfConfig shadow_msckf_cfg_{};
@@ -229,14 +221,7 @@ private:
     VisualFrontendMetrics last_visual_metrics_{};
     mutable std::mutex runtime_mutex_;
     RuntimeTelemetry runtime_telemetry_{};
-
     std::shared_ptr<spdlog::logger> logger_{spdlog::get("VIO")};
 };
 
 } // namespace drone::vio
-// System Designer and Developer: Md Shahanur Islam Shagor
-// Project: UVA GPS Denied Navigation in Dynamic Environments
-// Technology: C++, Python, Go, CMake
-// System Designer and Developer: Md Shahanur Islam Shagor
-// Project: UVA GPS Denied Navigation in Dynamic Environments
-// Technology: C++, Python, Go, CMake

--- a/include/vio/VisualFeatureTrackManager.hpp
+++ b/include/vio/VisualFeatureTrackManager.hpp
@@ -4,6 +4,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <Eigen/QR>
 
 #include <algorithm>
 #include <cmath>

--- a/include/vio/VisualFeatureTrackManager.hpp
+++ b/include/vio/VisualFeatureTrackManager.hpp
@@ -1,0 +1,243 @@
+#pragma once
+
+#include "vio/EKFEstimator.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace drone::vio {
+
+struct VisualFeatureTrackConfig {
+    double association_radius_px{3.0};
+    double minimum_baseline_m{0.05};
+    double minimum_parallax_deg{1.0};
+    double maximum_ray_gap_m{0.25};
+    double minimum_depth_m{0.10};
+    double maximum_depth_m{80.0};
+    std::size_t maximum_tracks{300};
+};
+
+struct TrackedVisualFeature {
+    uint64_t track_id{0};
+    Eigen::Vector2d pixel{Eigen::Vector2d::Zero()};
+    Eigen::Vector3d world_point{Eigen::Vector3d::Zero()};
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct VisualFeatureTrackBatch {
+    std::vector<TrackedVisualFeature, Eigen::aligned_allocator<TrackedVisualFeature>> features{};
+    uint64_t carried_tracks{0};
+    uint64_t new_tracks{0};
+    uint64_t initialized_tracks{0};
+    uint64_t rejected_geometry{0};
+};
+
+class VisualFeatureTrackManager {
+public:
+    explicit VisualFeatureTrackManager(VisualFeatureTrackConfig config = {}) : config_(config) {}
+
+    void reset() {
+        tracks_.clear();
+        next_track_id_ = 1;
+    }
+
+    [[nodiscard]] std::size_t track_count() const {
+        return tracks_.size();
+    }
+
+    [[nodiscard]] uint64_t next_track_id() const {
+        return next_track_id_;
+    }
+
+    [[nodiscard]] VisualFeatureTrackBatch update(
+        const std::vector<Eigen::Vector2d>& previous_pixels,
+        const std::vector<Eigen::Vector2d>& current_pixels,
+        const PoseEstimate& previous_pose,
+        const PoseEstimate& current_pose,
+        const Eigen::Matrix3d& K) {
+        VisualFeatureTrackBatch batch;
+        if (!inputs_valid(previous_pixels, current_pixels, previous_pose, current_pose, K)) {
+            tracks_.clear();
+            return batch;
+        }
+
+        const std::size_t count = previous_pixels.size();
+        std::vector<uint64_t> existing_ids;
+        existing_ids.reserve(tracks_.size());
+        for (const auto& [id, track] : tracks_) {
+            (void)track;
+            existing_ids.push_back(id);
+        }
+        std::sort(existing_ids.begin(), existing_ids.end());
+
+        std::unordered_set<uint64_t> claimed;
+        std::unordered_map<uint64_t, TrackState> next_tracks;
+        next_tracks.reserve(std::min(count, config_.maximum_tracks));
+
+        for (std::size_t i = 0; i < count && next_tracks.size() < config_.maximum_tracks; ++i) {
+            if (!previous_pixels[i].array().isFinite().all() ||
+                !current_pixels[i].array().isFinite().all()) {
+                ++batch.rejected_geometry;
+                continue;
+            }
+
+            const auto matched_id = match_track(previous_pixels[i], existing_ids, claimed);
+            TrackState state;
+            if (matched_id.has_value()) {
+                state = tracks_.at(*matched_id);
+                claimed.insert(*matched_id);
+                ++batch.carried_tracks;
+            } else {
+                state.track_id = next_track_id_++;
+                ++batch.new_tracks;
+            }
+
+            state.last_pixel = current_pixels[i];
+            if (!state.world_point.has_value()) {
+                const auto point = triangulate_two_view(previous_pixels[i], current_pixels[i],
+                                                        previous_pose, current_pose, K);
+                if (point.has_value()) {
+                    state.world_point = *point;
+                    ++batch.initialized_tracks;
+                } else {
+                    ++batch.rejected_geometry;
+                }
+            }
+
+            if (state.world_point.has_value()) {
+                batch.features.push_back(
+                    TrackedVisualFeature{state.track_id, current_pixels[i], *state.world_point});
+            }
+            next_tracks.emplace(state.track_id, std::move(state));
+        }
+
+        tracks_ = std::move(next_tracks);
+        std::sort(batch.features.begin(), batch.features.end(),
+                  [](const TrackedVisualFeature& lhs, const TrackedVisualFeature& rhs) {
+                      return lhs.track_id < rhs.track_id;
+                  });
+        return batch;
+    }
+
+private:
+    struct TrackState {
+        uint64_t track_id{0};
+        Eigen::Vector2d last_pixel{Eigen::Vector2d::Zero()};
+        std::optional<Eigen::Vector3d> world_point{};
+
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    };
+
+    [[nodiscard]] bool inputs_valid(const std::vector<Eigen::Vector2d>& previous_pixels,
+                                    const std::vector<Eigen::Vector2d>& current_pixels,
+                                    const PoseEstimate& previous_pose,
+                                    const PoseEstimate& current_pose,
+                                    const Eigen::Matrix3d& K) const {
+        if (previous_pixels.empty() || previous_pixels.size() != current_pixels.size()) {
+            return false;
+        }
+        if (config_.association_radius_px <= 0.0 || config_.minimum_baseline_m < 0.0 ||
+            config_.minimum_parallax_deg < 0.0 || config_.maximum_ray_gap_m <= 0.0 ||
+            config_.minimum_depth_m <= 0.0 ||
+            config_.maximum_depth_m <= config_.minimum_depth_m || config_.maximum_tracks == 0) {
+            return false;
+        }
+        return previous_pose.position.array().isFinite().all() &&
+               current_pose.position.array().isFinite().all() &&
+               previous_pose.orientation.coeffs().array().isFinite().all() &&
+               current_pose.orientation.coeffs().array().isFinite().all() &&
+               K.array().isFinite().all() && std::abs(K.determinant()) > 1.0e-12;
+    }
+
+    [[nodiscard]] std::optional<uint64_t>
+    match_track(const Eigen::Vector2d& previous_pixel, const std::vector<uint64_t>& ordered_ids,
+                const std::unordered_set<uint64_t>& claimed) const {
+        const double max_distance_sq = config_.association_radius_px * config_.association_radius_px;
+        double best_distance_sq = max_distance_sq;
+        std::optional<uint64_t> best_id;
+        for (const uint64_t id : ordered_ids) {
+            if (claimed.contains(id)) {
+                continue;
+            }
+            const auto it = tracks_.find(id);
+            if (it == tracks_.end()) {
+                continue;
+            }
+            const double distance_sq = (it->second.last_pixel - previous_pixel).squaredNorm();
+            if (distance_sq < best_distance_sq ||
+                (std::abs(distance_sq - best_distance_sq) <= 1.0e-12 &&
+                 (!best_id.has_value() || id < *best_id))) {
+                best_distance_sq = distance_sq;
+                best_id = id;
+            }
+        }
+        return best_id;
+    }
+
+    [[nodiscard]] std::optional<Eigen::Vector3d>
+    triangulate_two_view(const Eigen::Vector2d& previous_pixel,
+                         const Eigen::Vector2d& current_pixel, const PoseEstimate& previous_pose,
+                         const PoseEstimate& current_pose, const Eigen::Matrix3d& K) const {
+        const Eigen::Vector3d baseline = current_pose.position - previous_pose.position;
+        if (!baseline.array().isFinite().all() || baseline.norm() < config_.minimum_baseline_m) {
+            return std::nullopt;
+        }
+
+        const Eigen::Matrix3d K_inv = K.inverse();
+        Eigen::Vector3d ray_previous = previous_pose.R_wb() * K_inv *
+                                       Eigen::Vector3d{previous_pixel.x(), previous_pixel.y(), 1.0};
+        Eigen::Vector3d ray_current = current_pose.R_wb() * K_inv *
+                                      Eigen::Vector3d{current_pixel.x(), current_pixel.y(), 1.0};
+        if (!ray_previous.array().isFinite().all() || !ray_current.array().isFinite().all() ||
+            ray_previous.norm() <= 1.0e-12 || ray_current.norm() <= 1.0e-12) {
+            return std::nullopt;
+        }
+        ray_previous.normalize();
+        ray_current.normalize();
+
+        const double dot = std::clamp(ray_previous.dot(ray_current), -1.0, 1.0);
+        const double parallax_deg = std::acos(dot) * (180.0 / 3.14159265358979323846);
+        if (!std::isfinite(parallax_deg) || parallax_deg < config_.minimum_parallax_deg) {
+            return std::nullopt;
+        }
+
+        Eigen::Matrix<double, 3, 2> A;
+        A.col(0) = ray_previous;
+        A.col(1) = -ray_current;
+        const Eigen::Vector2d depths =
+            A.colPivHouseholderQr().solve(current_pose.position - previous_pose.position);
+        if (!depths.array().isFinite().all() || depths.x() < config_.minimum_depth_m ||
+            depths.y() < config_.minimum_depth_m || depths.x() > config_.maximum_depth_m ||
+            depths.y() > config_.maximum_depth_m) {
+            return std::nullopt;
+        }
+
+        const Eigen::Vector3d p_previous = previous_pose.position + depths.x() * ray_previous;
+        const Eigen::Vector3d p_current = current_pose.position + depths.y() * ray_current;
+        const double ray_gap = (p_previous - p_current).norm();
+        if (!std::isfinite(ray_gap) || ray_gap > config_.maximum_ray_gap_m) {
+            return std::nullopt;
+        }
+
+        const Eigen::Vector3d point = 0.5 * (p_previous + p_current);
+        if (!point.array().isFinite().all()) {
+            return std::nullopt;
+        }
+        return point;
+    }
+
+    VisualFeatureTrackConfig config_{};
+    std::unordered_map<uint64_t, TrackState> tracks_{};
+    uint64_t next_track_id_{1};
+};
+
+} // namespace drone::vio

--- a/src/vio/VIOPipeline.cpp
+++ b/src/vio/VIOPipeline.cpp
@@ -2,9 +2,6 @@
 // Project: UVA GPS Denied Navigation in Dynamic Environments
 // Technology: C++, Python, Go, CMake
 
-// VIOPipeline.cpp    Multi-sensor orchestration with lock-free event queue
-// Drone Swarm Sensor Fusion  |  Phase 2
-
 #include "vio/VIOPipeline.hpp"
 #include "vio/Phase17ESKFEstimator.hpp"
 
@@ -18,9 +15,7 @@
 #include <numeric>
 
 namespace drone::vio {
-
 namespace {
-
 constexpr size_t kMinTrackedFeatures = 24;
 constexpr double kMinInlierRatio = 0.55;
 constexpr double kMaxReprojectionErrorPx = 3.5;
@@ -42,19 +37,13 @@ bool thread_sanitizer_enabled() {
 
 void configure_opencv_threads_for_tsan() {
     static std::once_flag once;
-    if (!thread_sanitizer_enabled()) {
-        return;
-    }
+    if (!thread_sanitizer_enabled()) return;
     std::call_once(once, [] { cv::setNumThreads(1); });
 }
 
 cv::Mat to_gray(const cv::Mat& image) {
-    if (image.empty()) {
-        return {};
-    }
-    if (image.channels() == 1) {
-        return image.clone();
-    }
+    if (image.empty()) return {};
+    if (image.channels() == 1) return image.clone();
     cv::Mat gray;
     cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
     return gray;
@@ -64,22 +53,19 @@ double mean_optical_flow_error(const std::vector<float>& errors, const std::vect
     double sum = 0.0;
     size_t count = 0;
     for (size_t i = 0; i < errors.size() && i < status.size(); ++i) {
-        if (!status[i])
-            continue;
+        if (!status[i]) continue;
         sum += static_cast<double>(errors[i]);
         ++count;
     }
-    return count > 0 ? (sum / static_cast<double>(count)) : 1.0e6;
+    return count > 0 ? sum / static_cast<double>(count) : 1.0e6;
 }
-
 } // namespace
 
 VIOPipeline::VIOPipeline(EKFConfig cfg) : ekf_cfg_(cfg) {
     ShadowCoordinatorConfig shadow_cfg{};
     coordinator_ = std::make_unique<EstimatorCoordinator>(
         std::make_unique<EKFStateEstimatorAdapter>(ekf_cfg_, "ekf_active", "phase16"),
-        std::make_unique<Phase17StateEstimatorAdapter>(ekf_cfg_, "eskf_shadow", "phase17"),
-        shadow_cfg);
+        std::make_unique<Phase17StateEstimatorAdapter>(ekf_cfg_, "eskf_shadow", "phase17"), shadow_cfg);
 }
 
 bool visual_placeholder_allowed(drone::runtime::RuntimeMode mode) {
@@ -87,22 +73,14 @@ bool visual_placeholder_allowed(drone::runtime::RuntimeMode mode) {
 }
 
 double compute_visual_update_confidence(const VisualFrontendMetrics& metrics) {
-    if (metrics.tracked_feature_count == 0) {
-        return kDefaultVisualConfidenceOnFailure;
-    }
+    if (metrics.tracked_feature_count == 0) return kDefaultVisualConfidenceOnFailure;
     const double feature_score =
         std::clamp(static_cast<double>(metrics.tracked_feature_count) / 140.0, 0.0, 1.0);
     const double inlier_score = std::clamp(metrics.inlier_ratio, 0.0, 1.0);
-    const double reprojection_score =
-        std::clamp(1.0 - (metrics.reprojection_error / 8.0), 0.0, 1.0);
-    double confidence =
-        (feature_score * 0.35) + (inlier_score * 0.45) + (reprojection_score * 0.20);
-    if (!metrics.update_accepted) {
-        confidence *= 0.45;
-    }
-    if (metrics.used_placeholder) {
-        confidence = std::min(confidence, kDefaultVisualConfidenceOnPlaceholder);
-    }
+    const double reprojection_score = std::clamp(1.0 - metrics.reprojection_error / 8.0, 0.0, 1.0);
+    double confidence = feature_score * 0.35 + inlier_score * 0.45 + reprojection_score * 0.20;
+    if (!metrics.update_accepted) confidence *= 0.45;
+    if (metrics.used_placeholder) confidence = std::min(confidence, kDefaultVisualConfidenceOnPlaceholder);
     return std::clamp(confidence, 0.0, 1.0);
 }
 
@@ -118,8 +96,7 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
     }
 
     std::vector<cv::Point2f> previous_points;
-    cv::goodFeaturesToTrack(previous_gray, previous_points, static_cast<int>(kMaxFeatures), 0.01,
-                            8.0);
+    cv::goodFeaturesToTrack(previous_gray, previous_points, static_cast<int>(kMaxFeatures), 0.01, 8.0);
     if (previous_points.size() < 8) {
         result.metrics.tracked_feature_count = previous_points.size();
         result.metrics.visual_update_confidence = kDefaultVisualConfidenceOnFailure;
@@ -137,12 +114,10 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
     tracked_prev.reserve(previous_points.size());
     tracked_curr.reserve(previous_points.size());
     for (size_t i = 0; i < previous_points.size() && i < status.size(); ++i) {
-        if (!status[i])
-            continue;
+        if (!status[i]) continue;
         tracked_prev.push_back(previous_points[i]);
         tracked_curr.push_back(current_points[i]);
     }
-
     result.metrics.tracked_feature_count = tracked_curr.size();
     result.metrics.reprojection_error = mean_optical_flow_error(errors, status);
     if (tracked_curr.size() < 8) {
@@ -152,14 +127,12 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     cv::Mat K_cv(3, 3, CV_64F);
     for (int r = 0; r < 3; ++r) {
-        for (int c = 0; c < 3; ++c) {
-            K_cv.at<double>(r, c) = K(r, c);
-        }
+        for (int c = 0; c < 3; ++c) K_cv.at<double>(r, c) = K(r, c);
     }
 
     cv::Mat inlier_mask;
-    const cv::Mat essential =
-        cv::findEssentialMat(tracked_prev, tracked_curr, K_cv, cv::RANSAC, 0.999, 1.5, inlier_mask);
+    const cv::Mat essential = cv::findEssentialMat(tracked_prev, tracked_curr, K_cv, cv::RANSAC,
+                                                    0.999, 1.5, inlier_mask);
     if (essential.empty() || inlier_mask.empty()) {
         result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
         return result;
@@ -167,27 +140,36 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     int inlier_count = 0;
     for (int i = 0; i < inlier_mask.rows; ++i) {
-        if (inlier_mask.at<uchar>(i, 0) != 0) {
-            ++inlier_count;
-        }
+        if (inlier_mask.at<uchar>(i, 0) != 0) ++inlier_count;
     }
-    result.metrics.inlier_ratio =
-        tracked_curr.empty()
-            ? 0.0
-            : static_cast<double>(inlier_count) / static_cast<double>(tracked_curr.size());
+    result.metrics.inlier_ratio = tracked_curr.empty()
+                                      ? 0.0
+                                      : static_cast<double>(inlier_count) /
+                                            static_cast<double>(tracked_curr.size());
 
     cv::Mat R_cv;
     cv::Mat t_cv;
     cv::Mat recover_mask;
-    const int recovered =
-        cv::recoverPose(essential, tracked_prev, tracked_curr, K_cv, R_cv, t_cv, recover_mask);
+    const int recovered = cv::recoverPose(essential, tracked_prev, tracked_curr, K_cv, R_cv, t_cv,
+                                          recover_mask);
     if (recovered < static_cast<int>(kMinTrackedFeatures / 2)) {
         result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
         return result;
     }
 
-    const Eigen::Vector3d predicted_delta =
-        current_predicted_pose.position - previous_pose.position;
+    result.previous_inlier_pixels.reserve(tracked_prev.size());
+    result.current_inlier_pixels.reserve(tracked_curr.size());
+    for (size_t i = 0; i < tracked_prev.size(); ++i) {
+        const bool essential_inlier = i < static_cast<size_t>(inlier_mask.rows) &&
+                                      inlier_mask.at<uchar>(static_cast<int>(i), 0) != 0;
+        const bool pose_inlier = i < static_cast<size_t>(recover_mask.rows) &&
+                                 recover_mask.at<uchar>(static_cast<int>(i), 0) != 0;
+        if (!essential_inlier || !pose_inlier) continue;
+        result.previous_inlier_pixels.emplace_back(tracked_prev[i].x, tracked_prev[i].y);
+        result.current_inlier_pixels.emplace_back(tracked_curr[i].x, tracked_curr[i].y);
+    }
+
+    const Eigen::Vector3d predicted_delta = current_predicted_pose.position - previous_pose.position;
     const double predicted_scale =
         std::max(predicted_delta.norm(), current_predicted_pose.velocity.norm() * dt_s);
     if (predicted_scale < 1.0e-4) {
@@ -197,27 +179,20 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     Eigen::Matrix3d relative_rotation = Eigen::Matrix3d::Identity();
     for (int r = 0; r < 3; ++r) {
-        for (int c = 0; c < 3; ++c) {
-            relative_rotation(r, c) = R_cv.at<double>(r, c);
-        }
+        for (int c = 0; c < 3; ++c) relative_rotation(r, c) = R_cv.at<double>(r, c);
     }
-    Eigen::Vector3d translation_direction{
-        t_cv.at<double>(0, 0),
-        t_cv.at<double>(1, 0),
-        t_cv.at<double>(2, 0),
-    };
+    Eigen::Vector3d translation_direction{t_cv.at<double>(0, 0), t_cv.at<double>(1, 0),
+                                          t_cv.at<double>(2, 0)};
     if (translation_direction.norm() < 1.0e-6) {
         result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
         return result;
     }
     translation_direction.normalize();
-
     const Eigen::Vector3d world_translation =
         previous_pose.R_wb() * translation_direction * predicted_scale;
     result.observed_position = previous_pose.position + world_translation;
     result.observed_velocity = world_translation / dt_s;
     result.relative_orientation = Eigen::Quaterniond(relative_rotation).normalized();
-
     result.metrics.update_accepted = result.metrics.tracked_feature_count >= kMinTrackedFeatures &&
                                      result.metrics.inlier_ratio >= kMinInlierRatio &&
                                      result.metrics.reprojection_error <= kMaxReprojectionErrorPx;
@@ -230,29 +205,18 @@ VisualFrontendResult build_placeholder_visual_frontend_result(const sensors::Cam
                                                               const Eigen::Matrix3d& K) {
     VisualFrontendResult result;
     result.metrics.used_placeholder = true;
-
-    std::vector<Eigen::Vector2d> z_pixels;
-    std::vector<Eigen::Vector3d> p_world;
+    size_t accepted = 0;
     for (const auto& det : frame.detections) {
-        if (det.confidence < 0.6f)
-            continue;
-        const float cx_px =
-            (det.bbox.x + det.bbox.width * 0.5f) * static_cast<float>(K(0, 2)) * 2.0f;
-        const float cy_px =
-            (det.bbox.y + det.bbox.height * 0.5f) * static_cast<float>(K(1, 2)) * 2.0f;
-        z_pixels.push_back({cx_px, cy_px});
-
-        const Eigen::Vector3d forward = pose.R_wb() * Eigen::Vector3d{0.0, 0.0, 1.0};
-        p_world.push_back(pose.position + forward * 5.0);
+        if (det.confidence >= 0.6f) ++accepted;
     }
-
-    result.metrics.tracked_feature_count = z_pixels.size();
-    result.metrics.inlier_ratio = z_pixels.empty() ? 0.0 : 1.0;
-    result.metrics.reprojection_error = z_pixels.empty() ? 1.0e6 : 0.5;
-    result.metrics.update_accepted = !z_pixels.empty();
+    result.metrics.tracked_feature_count = accepted;
+    result.metrics.inlier_ratio = accepted == 0 ? 0.0 : 1.0;
+    result.metrics.reprojection_error = accepted == 0 ? 1.0e6 : 0.5;
+    result.metrics.update_accepted = accepted != 0;
     result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
     result.observed_position = pose.position;
     result.observed_velocity = pose.velocity;
+    (void)K;
     return result;
 }
 
@@ -272,49 +236,44 @@ void VIOPipeline::attach_lidar(std::shared_ptr<sensors::LidarSensor> lidar) {
 }
 
 bool VIOPipeline::start() {
-    if (running_.exchange(true))
-        return true;
-
+    if (running_.exchange(true)) return true;
     if (coordinator_) {
         coordinator_->initialize();
         (void)coordinator_->start();
     }
-
     proc_thread_ = std::thread([this] { processing_loop(); });
-
-    if (logger_)
-        logger_->info("VIO pipeline started");
+    if (logger_) logger_->info("VIO pipeline started");
     return true;
 }
 
 void VIOPipeline::stop() {
-    if (!running_.exchange(false))
-        return;
+    if (!running_.exchange(false)) return;
     queue_cv_.notify_all();
-    if (proc_thread_.joinable())
-        proc_thread_.join();
-    if (coordinator_) {
-        coordinator_->stop();
-    }
-    if (logger_)
-        logger_->info("VIO pipeline stopped");
+    if (proc_thread_.joinable()) proc_thread_.join();
+    if (coordinator_) coordinator_->stop();
+    if (logger_) logger_->info("VIO pipeline stopped");
 }
 
 void VIOPipeline::reset() {
     std::lock_guard lock(queue_mutex_);
-    while (!event_queue_.empty())
-        event_queue_.pop();
-    if (coordinator_) {
-        coordinator_->reset();
-    }
+    while (!event_queue_.empty()) event_queue_.pop();
+    if (coordinator_) coordinator_->reset();
     last_imu_ts_ = -1.0;
     last_camera_ts_ = -1.0;
     measurement_sequence_ = 0;
     previous_gray_frame_.release();
     previous_camera_pose_valid_ = false;
+    visual_feature_tracks_.reset();
     {
         std::lock_guard visual_lock(visual_metrics_mutex_);
         last_visual_metrics_ = {};
+    }
+    {
+        std::lock_guard runtime_lock(runtime_mutex_);
+        runtime_telemetry_.persistent_feature_tracks = 0;
+        runtime_telemetry_.initialized_feature_tracks = 0;
+        runtime_telemetry_.rejected_feature_geometry = 0;
+        runtime_telemetry_.shadow_feature_batches_submitted = 0;
     }
 }
 
@@ -331,11 +290,7 @@ PoseEstimate VIOPipeline::current_pose() const {
 void VIOPipeline::enqueue(SensorEvent evt) {
     {
         std::lock_guard lock(queue_mutex_);
-        if (event_queue_.size() > 2000) {
-            event_queue_.pop();
-            if (logger_)
-                logger_->warn("VIO queue overflow  dropping oldest event");
-        }
+        if (event_queue_.size() > 2000) event_queue_.pop();
         event_queue_.push(std::move(evt));
     }
     queue_cv_.notify_one();
@@ -347,43 +302,69 @@ void VIOPipeline::processing_loop() {
         {
             std::unique_lock lock(queue_mutex_);
             queue_cv_.wait(lock, [this] { return !event_queue_.empty() || !running_.load(); });
-            if (!running_.load() && event_queue_.empty())
-                return;
+            if (!running_.load() && event_queue_.empty()) return;
             evt = std::move(event_queue_.front());
             event_queue_.pop();
         }
-
         std::visit([this](auto&& e) { handle(e); }, evt);
-
-        if (pose_cb_) {
-            pose_cb_(current_pose());
-        }
+        if (pose_cb_) pose_cb_(current_pose());
     }
 }
 
 void VIOPipeline::handle(const sensors::ImuMeasurement& imu) {
-    if (!coordinator_) {
-        return;
-    }
-    if (!coordinator_->active_snapshot().initialized) {
-        coordinator_->initialize();
-    }
+    if (!coordinator_) return;
+    if (!coordinator_->active_snapshot().initialized) coordinator_->initialize();
     last_imu_ts_ = imu.timestamp;
     (void)coordinator_->process_measurement(make_imu_envelope(imu, measurement_sequence_++));
     refresh_runtime_telemetry_from_coordinator();
 }
 
+void VIOPipeline::submit_tracked_features_to_shadow(const VisualFrontendResult& frontend_result,
+                                                     const PoseEstimate& previous_pose,
+                                                     const PoseEstimate& current_pose,
+                                                     double timestamp_s) {
+    if (!coordinator_ || frontend_result.previous_inlier_pixels.empty() ||
+        frontend_result.previous_inlier_pixels.size() !=
+            frontend_result.current_inlier_pixels.size()) {
+        return;
+    }
+
+    const auto batch = visual_feature_tracks_.update(frontend_result.previous_inlier_pixels,
+                                                     frontend_result.current_inlier_pixels,
+                                                     previous_pose, current_pose, K_);
+    {
+        std::lock_guard lock(runtime_mutex_);
+        runtime_telemetry_.persistent_feature_tracks = visual_feature_tracks_.track_count();
+        runtime_telemetry_.initialized_feature_tracks += batch.initialized_tracks;
+        runtime_telemetry_.rejected_feature_geometry += batch.rejected_geometry;
+    }
+    if (batch.features.empty()) return;
+
+    VisualFeatureMeasurementPayload payload;
+    payload.K = K_;
+    payload.z_pixels.reserve(batch.features.size());
+    payload.p_world.reserve(batch.features.size());
+    for (const auto& feature : batch.features) {
+        payload.z_pixels.push_back(feature.pixel);
+        payload.p_world.push_back(feature.world_point);
+    }
+
+    const auto result = coordinator_->submit_shadow_measurement(make_visual_features_envelope(
+        payload, MeasurementStamp{timestamp_s, measurement_sequence_++}));
+    if (result == EstimatorOperationResult::Accepted) {
+        std::lock_guard lock(runtime_mutex_);
+        ++runtime_telemetry_.shadow_feature_batches_submitted;
+    }
+}
+
 void VIOPipeline::handle(const sensors::CameraFrame& frame) {
-    if (!coordinator_ || !coordinator_->active_snapshot().initialized)
-        return;
-    if (frame.detections.empty() && frame.image.empty())
-        return;
+    if (!coordinator_ || !coordinator_->active_snapshot().initialized) return;
+    if (frame.detections.empty() && frame.image.empty()) return;
 
     const auto predicted_pose = coordinator_->active_pose();
     VisualFrontendResult frontend_result;
     cv::Mat current_gray = to_gray(frame.image);
-    const double dt = (last_camera_ts_ > 0.0) ? (frame.timestamp - last_camera_ts_) : 0.0;
-
+    const double dt = last_camera_ts_ > 0.0 ? frame.timestamp - last_camera_ts_ : 0.0;
     if (!previous_gray_frame_.empty() && !current_gray.empty() && previous_camera_pose_valid_ &&
         dt > 0.0) {
         frontend_result = run_visual_frontend(previous_gray_frame_, current_gray, K_,
@@ -393,52 +374,23 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
     }
 
     if (frontend_result.metrics.update_accepted) {
-        const double sigma_position_m = std::clamp(
-            0.50 - (frontend_result.metrics.visual_update_confidence * 0.28), 0.14, 0.50);
-        const double sigma_velocity_mps = std::clamp(
-            0.65 - (frontend_result.metrics.visual_update_confidence * 0.30), 0.18, 0.65);
         VisualPoseMeasurementPayload payload;
         payload.position_m = frontend_result.observed_position;
         payload.velocity_mps = frontend_result.observed_velocity;
-        payload.sigma_position_m = sigma_position_m;
-        payload.sigma_velocity_mps = sigma_velocity_mps;
+        payload.sigma_position_m = std::clamp(
+            0.50 - frontend_result.metrics.visual_update_confidence * 0.28, 0.14, 0.50);
+        payload.sigma_velocity_mps = std::clamp(
+            0.65 - frontend_result.metrics.visual_update_confidence * 0.30, 0.18, 0.65);
         (void)coordinator_->process_measurement(make_visual_pose_envelope(
             payload, MeasurementStamp{frame.timestamp, measurement_sequence_++}));
+        submit_tracked_features_to_shadow(frontend_result, previous_camera_pose_, predicted_pose,
+                                          frame.timestamp);
     } else if (visual_placeholder_allowed(runtime_mode_) && !frame.detections.empty()) {
-        const auto placeholder =
-            build_placeholder_visual_frontend_result(frame, predicted_pose, K_);
-        frontend_result = placeholder;
-
-        std::vector<Eigen::Vector2d> z_pixels;
-        std::vector<Eigen::Vector3d> p_world;
-        for (const auto& det : frame.detections) {
-            if (det.confidence < 0.6f)
-                continue;
-            const float cx_px =
-                (det.bbox.x + det.bbox.width * 0.5f) * static_cast<float>(K_(0, 2)) * 2.0f;
-            const float cy_px =
-                (det.bbox.y + det.bbox.height * 0.5f) * static_cast<float>(K_(1, 2)) * 2.0f;
-            z_pixels.push_back({cx_px, cy_px});
-
-            const Eigen::Vector3d forward = predicted_pose.R_wb() * Eigen::Vector3d{0.0, 0.0, 1.0};
-            p_world.push_back(predicted_pose.position + forward * 5.0);
-        }
-        if (!z_pixels.empty()) {
-            // Preserve the production baseline authority: the simulation placeholder pose may
-            // update the active estimator, while feature tracks are published only to the shadow
-            // estimator. The queue preserves visual-pose-before-feature ordering for the shadow.
-            (void)coordinator_->process_measurement(make_visual_pose_envelope(
-                VisualPoseMeasurementPayload{predicted_pose.position, predicted_pose.velocity, 0.35,
-                                             0.45},
-                MeasurementStamp{frame.timestamp, measurement_sequence_++}));
-
-            VisualFeatureMeasurementPayload feature_payload;
-            feature_payload.z_pixels.assign(z_pixels.begin(), z_pixels.end());
-            feature_payload.p_world.assign(p_world.begin(), p_world.end());
-            feature_payload.K = K_;
-            (void)coordinator_->submit_shadow_measurement(make_visual_features_envelope(
-                feature_payload, MeasurementStamp{frame.timestamp, measurement_sequence_++}));
-        }
+        frontend_result = build_placeholder_visual_frontend_result(frame, predicted_pose, K_);
+        (void)coordinator_->process_measurement(make_visual_pose_envelope(
+            VisualPoseMeasurementPayload{predicted_pose.position, predicted_pose.velocity, 0.35,
+                                         0.45},
+            MeasurementStamp{frame.timestamp, measurement_sequence_++}));
     }
 
     {
@@ -464,26 +416,21 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
 }
 
 void VIOPipeline::handle(const sensors::LidarMeasurement& lidar) {
-    if (!coordinator_ || !coordinator_->active_snapshot().initialized || !lidar.cloud)
+    if (!coordinator_ || !coordinator_->active_snapshot().initialized || !lidar.cloud ||
+        lidar.cloud->empty()) {
         return;
-
-    if (lidar.cloud->empty())
-        return;
-
+    }
     std::vector<float> z_vals;
     z_vals.reserve(lidar.cloud->size());
-    for (const auto& pt : *lidar.cloud)
-        if (pt.z > -20.0f && pt.z < 0.5f)
-            z_vals.push_back(pt.z);
-
-    if (z_vals.empty())
-        return;
-
+    for (const auto& pt : *lidar.cloud) {
+        if (pt.z > -20.0f && pt.z < 0.5f) z_vals.push_back(pt.z);
+    }
+    if (z_vals.empty()) return;
     const auto median_index = z_vals.size() / 2;
-    const auto median_offset = static_cast<std::vector<float>::difference_type>(median_index);
-    std::nth_element(z_vals.begin(), z_vals.begin() + median_offset, z_vals.end());
+    std::nth_element(z_vals.begin(),
+                     z_vals.begin() + static_cast<std::vector<float>::difference_type>(median_index),
+                     z_vals.end());
     const double ground_z = z_vals[median_index];
-
     const auto pose = coordinator_->active_pose();
     const double height = pose.position.z() - ground_z;
     if (height > 0.3 && height < 100.0) {
@@ -500,15 +447,10 @@ void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
         std::lock_guard lock(visual_metrics_mutex_);
         metrics = last_visual_metrics_;
     }
-
-    if (metrics.visual_update_confidence <= 0.0) {
-        return;
-    }
-
+    if (metrics.visual_update_confidence <= 0.0) return;
     pose.localization_confidence = std::clamp(
         pose.localization_confidence * std::clamp(metrics.visual_update_confidence, 0.18, 1.0), 0.0,
         1.0);
-
     if (metrics.tracked_feature_count < kMinTrackedFeatures ||
         metrics.inlier_ratio < kMinInlierRatio ||
         metrics.reprojection_error > kMaxReprojectionErrorPx) {
@@ -516,9 +458,7 @@ void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
         pose.localization_source =
             metrics.used_placeholder ? "simulation-placeholder-vision" : "low-visual-quality";
     }
-    if (pose.localization_confidence < 0.22) {
-        pose.localization_lost = true;
-    }
+    if (pose.localization_confidence < 0.22) pose.localization_lost = true;
 }
 
 void VIOPipeline::set_estimator_validation_config(const EstimatorValidationConfig& cfg) {
@@ -532,15 +472,13 @@ void VIOPipeline::set_shadow_msckf_config(const MsckfConfig& cfg) {
 }
 
 void VIOPipeline::reconfigure_coordinator() {
-    if (coordinator_) {
-        coordinator_->configure_validation(estimator_validation_cfg_);
-        coordinator_->configure_shadow_msckf(shadow_msckf_cfg_);
-        coordinator_->stop();
-        coordinator_->initialize();
-        if (running_.load()) {
-            (void)coordinator_->start();
-        }
-    }
+    if (!coordinator_) return;
+    coordinator_->configure_validation(estimator_validation_cfg_);
+    coordinator_->configure_shadow_msckf(shadow_msckf_cfg_);
+    coordinator_->stop();
+    coordinator_->initialize();
+    visual_feature_tracks_.reset();
+    if (running_.load()) (void)coordinator_->start();
 }
 
 double VIOPipeline::drift_m() const {
@@ -548,9 +486,7 @@ double VIOPipeline::drift_m() const {
 }
 
 void VIOPipeline::refresh_runtime_telemetry_from_coordinator() {
-    if (!coordinator_) {
-        return;
-    }
+    if (!coordinator_) return;
     const auto diagnostics = coordinator_->diagnostics();
     std::lock_guard lock(runtime_mutex_);
     runtime_telemetry_.active_estimator_name = diagnostics.active_estimator_name;
@@ -563,10 +499,8 @@ void VIOPipeline::refresh_runtime_telemetry_from_coordinator() {
     runtime_telemetry_.shadow_queue_high_water_mark = diagnostics.queue.peak_depth;
     runtime_telemetry_.shadow_dropped_events = diagnostics.queue.dropped_count;
     runtime_telemetry_.shadow_position_delta_m = diagnostics.last_comparison.position_delta_norm_m;
-    runtime_telemetry_.shadow_velocity_delta_mps =
-        diagnostics.last_comparison.velocity_delta_norm_mps;
-    runtime_telemetry_.shadow_orientation_delta_deg =
-        diagnostics.last_comparison.orientation_delta_deg;
+    runtime_telemetry_.shadow_velocity_delta_mps = diagnostics.last_comparison.velocity_delta_norm_mps;
+    runtime_telemetry_.shadow_orientation_delta_deg = diagnostics.last_comparison.orientation_delta_deg;
     runtime_telemetry_.shadow_divergence_active =
         diagnostics.last_comparison.valid &&
         (diagnostics.last_comparison.position_delta_norm_m >
@@ -580,6 +514,3 @@ void VIOPipeline::refresh_runtime_telemetry_from_coordinator() {
 }
 
 } // namespace drone::vio
-// System Designer and Developer: Md Shahanur Islam Shagor
-// Project: UVA GPS Denied Navigation in Dynamic Environments
-// Technology: C++, Python, Go, CMake

--- a/tests/test_visual_feature_track_ingest.cpp
+++ b/tests/test_visual_feature_track_ingest.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include "vio/EstimatorCoordinator.hpp"
+#include "vio/Phase17ESKFEstimator.hpp"
+#include "vio/VisualFeatureTrackManager.hpp"
+
+namespace drone::vio {
+namespace {
+
+Eigen::Matrix3d intrinsics() {
+    Eigen::Matrix3d K = Eigen::Matrix3d::Zero();
+    K(0, 0) = 320.0;
+    K(1, 1) = 320.0;
+    K(0, 2) = 320.0;
+    K(1, 2) = 240.0;
+    K(2, 2) = 1.0;
+    return K;
+}
+
+PoseEstimate pose_at(double x) {
+    PoseEstimate pose;
+    pose.position = Eigen::Vector3d{x, 0.0, 0.0};
+    pose.orientation = Eigen::Quaterniond::Identity();
+    return pose;
+}
+
+VisualFeatureTrackBatch make_batch() {
+    VisualFeatureTrackConfig cfg;
+    cfg.minimum_baseline_m = 0.05;
+    cfg.minimum_parallax_deg = 0.1;
+    cfg.maximum_ray_gap_m = 0.5;
+    VisualFeatureTrackManager manager(cfg);
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}, {340.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{312.0, 240.0}, {332.0, 240.0}};
+    return manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+}
+
+TEST(VisualFeatureTrackIngest, ShadowOnlyFeatureSubmissionPreservesActiveState) {
+    ShadowCoordinatorConfig shadow_cfg;
+    shadow_cfg.enabled = true;
+    shadow_cfg.start_worker_on_initialize = true;
+
+    EstimatorCoordinator coordinator(
+        std::make_unique<EKFStateEstimatorAdapter>(EKFConfig{}, "ekf_active", "baseline"),
+        std::make_unique<Phase17StateEstimatorAdapter>(EKFConfig{}, "eskf_shadow", "hardened"),
+        shadow_cfg);
+
+    coordinator.initialize();
+    ASSERT_TRUE(coordinator.start());
+
+    const auto before = coordinator.active_snapshot();
+    const auto batch = make_batch();
+    ASSERT_FALSE(batch.features.empty());
+
+    VisualFeatureMeasurementPayload payload;
+    payload.K = intrinsics();
+    for (const auto& feature : batch.features) {
+        payload.z_pixels.push_back(feature.pixel);
+        payload.p_world.push_back(feature.world_point);
+    }
+
+    EXPECT_EQ(coordinator.submit_shadow_measurement(
+                  make_visual_features_envelope(payload, MeasurementStamp{0.10, 1})),
+              EstimatorOperationResult::Accepted);
+    coordinator.flush_shadow();
+
+    const auto after = coordinator.active_snapshot();
+    EXPECT_NEAR((after.position_m - before.position_m).norm(), 0.0, 1.0e-12);
+    EXPECT_NEAR((after.velocity_mps - before.velocity_mps).norm(), 0.0, 1.0e-12);
+    EXPECT_NEAR(std::abs(after.orientation.dot(before.orientation)), 1.0, 1.0e-12);
+    EXPECT_DOUBLE_EQ(after.covariance.trace, before.covariance.trace);
+
+    const auto diagnostics = coordinator.diagnostics();
+    EXPECT_EQ(diagnostics.active_processed_count, 0u);
+    EXPECT_EQ(diagnostics.shadow_only_submission_count, 1u);
+    EXPECT_EQ(diagnostics.queue.current_depth, 0u);
+    EXPECT_GE(diagnostics.shadow_processed_count, 1u);
+    coordinator.stop();
+}
+
+TEST(VisualFeatureTrackIngest, RepeatedSyntheticTracksRemainDeterministic) {
+    VisualFeatureTrackConfig cfg;
+    cfg.minimum_baseline_m = 0.05;
+    cfg.minimum_parallax_deg = 0.1;
+    cfg.maximum_ray_gap_m = 0.5;
+
+    auto run = [&cfg]() {
+        VisualFeatureTrackManager manager(cfg);
+        std::vector<uint64_t> ids;
+        const std::vector<Eigen::Vector2d> p0{{320.0, 240.0}, {340.0, 240.0}};
+        const std::vector<Eigen::Vector2d> p1{{312.0, 240.0}, {332.0, 240.0}};
+        const std::vector<Eigen::Vector2d> p2{{304.0, 240.0}, {324.0, 240.0}};
+
+        const auto first = manager.update(p0, p1, pose_at(0.0), pose_at(0.10), intrinsics());
+        const auto second = manager.update(p1, p2, pose_at(0.10), pose_at(0.20), intrinsics());
+        for (const auto& feature : first.features) {
+            ids.push_back(feature.track_id);
+        }
+        for (const auto& feature : second.features) {
+            ids.push_back(feature.track_id);
+        }
+        return ids;
+    };
+
+    EXPECT_EQ(run(), run());
+}
+
+} // namespace
+} // namespace drone::vio

--- a/tests/test_visual_feature_track_manager.cpp
+++ b/tests/test_visual_feature_track_manager.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "vio/VisualFeatureTrackManager.hpp"
+
+namespace drone::vio {
+namespace {
+
+Eigen::Matrix3d intrinsics() {
+    Eigen::Matrix3d K = Eigen::Matrix3d::Zero();
+    K(0, 0) = 320.0;
+    K(1, 1) = 320.0;
+    K(0, 2) = 320.0;
+    K(1, 2) = 240.0;
+    K(2, 2) = 1.0;
+    return K;
+}
+
+PoseEstimate pose_at(double x) {
+    PoseEstimate pose;
+    pose.position = Eigen::Vector3d{x, 0.0, 0.0};
+    pose.orientation = Eigen::Quaterniond::Identity();
+    return pose;
+}
+
+TEST(VisualFeatureTrackManager, StableTrackIdAndWorldPointAcrossFrames) {
+    VisualFeatureTrackConfig cfg;
+    cfg.minimum_baseline_m = 0.05;
+    cfg.minimum_parallax_deg = 0.1;
+    cfg.maximum_ray_gap_m = 0.5;
+    VisualFeatureTrackManager manager(cfg);
+
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{312.0, 240.0}};
+    const auto first = manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+    ASSERT_EQ(first.features.size(), 1u);
+    const auto track_id = first.features.front().track_id;
+    const auto world_point = first.features.front().world_point;
+    EXPECT_EQ(track_id, 1u);
+    EXPECT_TRUE(world_point.array().isFinite().all());
+
+    const std::vector<Eigen::Vector2d> next{{304.0, 240.0}};
+    const auto second = manager.update(current, next, pose_at(0.10), pose_at(0.20), intrinsics());
+    ASSERT_EQ(second.features.size(), 1u);
+    EXPECT_EQ(second.features.front().track_id, track_id);
+    EXPECT_NEAR((second.features.front().world_point - world_point).norm(), 0.0, 1.0e-12);
+    EXPECT_EQ(second.carried_tracks, 1u);
+}
+
+TEST(VisualFeatureTrackManager, LowParallaxDoesNotPublishUninitializedTrack) {
+    VisualFeatureTrackConfig cfg;
+    cfg.minimum_baseline_m = 0.05;
+    cfg.minimum_parallax_deg = 2.0;
+    VisualFeatureTrackManager manager(cfg);
+
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{319.9, 240.0}};
+    const auto batch = manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+
+    EXPECT_TRUE(batch.features.empty());
+    EXPECT_EQ(batch.initialized_tracks, 0u);
+    EXPECT_EQ(batch.rejected_geometry, 1u);
+    EXPECT_EQ(manager.track_count(), 1u);
+}
+
+TEST(VisualFeatureTrackManager, InvalidInputFailsClosedAndClearsTransientTracks) {
+    VisualFeatureTrackManager manager;
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{312.0, 240.0}};
+    (void)manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+    ASSERT_EQ(manager.track_count(), 1u);
+
+    const std::vector<Eigen::Vector2d> mismatched{{312.0, 240.0}, {300.0, 220.0}};
+    const auto rejected = manager.update(previous, mismatched, pose_at(0.10), pose_at(0.20), intrinsics());
+    EXPECT_TRUE(rejected.features.empty());
+    EXPECT_EQ(manager.track_count(), 0u);
+}
+
+TEST(VisualFeatureTrackManager, ResetRestartsIdsDeterministically) {
+    VisualFeatureTrackManager manager;
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{312.0, 240.0}};
+    (void)manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+    EXPECT_GT(manager.next_track_id(), 1u);
+
+    manager.reset();
+    EXPECT_EQ(manager.track_count(), 0u);
+    EXPECT_EQ(manager.next_track_id(), 1u);
+}
+
+TEST(VisualFeatureTrackManager, DeterministicTieBreakUsesLowestTrackId) {
+    VisualFeatureTrackConfig cfg;
+    cfg.association_radius_px = 5.0;
+    cfg.minimum_parallax_deg = 0.1;
+    VisualFeatureTrackManager manager(cfg);
+
+    const std::vector<Eigen::Vector2d> previous{{320.0, 240.0}, {324.0, 240.0}};
+    const std::vector<Eigen::Vector2d> current{{312.0, 240.0}, {316.0, 240.0}};
+    const auto first = manager.update(previous, current, pose_at(0.0), pose_at(0.10), intrinsics());
+    ASSERT_EQ(first.features.size(), 2u);
+    EXPECT_LT(first.features[0].track_id, first.features[1].track_id);
+
+    const std::vector<Eigen::Vector2d> ambiguous_previous{{314.0, 240.0}};
+    const std::vector<Eigen::Vector2d> next{{306.0, 240.0}};
+    const auto second =
+        manager.update(ambiguous_previous, next, pose_at(0.10), pose_at(0.20), intrinsics());
+    ASSERT_EQ(second.features.size(), 1u);
+    EXPECT_EQ(second.features.front().track_id, first.features.front().track_id);
+}
+
+} // namespace
+} // namespace drone::vio

--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -1,8 +1,3 @@
-set(VISUAL_FEATURE_TRACK_TEST_CORE sensor_fusion_core)
-if(TARGET phase17_estimator_headless_core)
-    set(VISUAL_FEATURE_TRACK_TEST_CORE phase17_estimator_headless_core)
-endif()
-
 add_executable(test_visual_feature_track_manager
     "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_manager.cpp"
 )
@@ -10,23 +5,43 @@ target_link_libraries(test_visual_feature_track_manager PRIVATE
     drone_test_support
     Eigen3::Eigen
 )
-drone_register_gtest(test_visual_feature_track_manager "unit;navigation;visual-feature-tracking")
+drone_apply_project_warnings(test_visual_feature_track_manager)
+drone_enable_coverage(test_visual_feature_track_manager)
+drone_enable_sanitizers(test_visual_feature_track_manager)
+drone_set_target_output_dirs(test_visual_feature_track_manager "tests" "tests" "tests")
+add_test(
+    NAME test_visual_feature_track_manager
+    COMMAND $<TARGET_FILE:test_visual_feature_track_manager>
+)
+set_tests_properties(test_visual_feature_track_manager PROPERTIES
+    LABELS "unit;navigation;visual-feature-tracking"
+)
 
 add_executable(test_visual_feature_track_ingest
     "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_ingest.cpp"
 )
 target_link_libraries(test_visual_feature_track_ingest PRIVATE
     drone_test_support
-    ${VISUAL_FEATURE_TRACK_TEST_CORE}
+    ${DRONE_PHASE17_TEST_CORE}
     Eigen3::Eigen
 )
-drone_register_gtest(test_visual_feature_track_ingest "unit;navigation;shadow-only;visual-feature-tracking")
+drone_apply_project_warnings(test_visual_feature_track_ingest)
+drone_enable_coverage(test_visual_feature_track_ingest)
+drone_enable_sanitizers(test_visual_feature_track_ingest)
+drone_set_target_output_dirs(test_visual_feature_track_ingest "tests" "tests" "tests")
+add_test(
+    NAME test_visual_feature_track_ingest
+    COMMAND $<TARGET_FILE:test_visual_feature_track_ingest>
+)
+set_tests_properties(test_visual_feature_track_ingest PROPERTIES
+    LABELS "unit;navigation;shadow-only;visual-feature-tracking"
+)
 
 add_executable(visual_feature_track_ingest_replay
     "${CMAKE_CURRENT_LIST_DIR}/visual_feature_track_ingest_replay.cpp"
 )
 target_link_libraries(visual_feature_track_ingest_replay PRIVATE
-    ${VISUAL_FEATURE_TRACK_TEST_CORE}
+    ${DRONE_PHASE17_TEST_CORE}
     Eigen3::Eigen
 )
 drone_apply_project_warnings(visual_feature_track_ingest_replay)
@@ -35,4 +50,5 @@ drone_enable_sanitizers(visual_feature_track_ingest_replay)
 drone_set_target_output_dirs(visual_feature_track_ingest_replay "tests" "tests" "tests")
 add_test(NAME visual_feature_track_ingest_replay COMMAND $<TARGET_FILE:visual_feature_track_ingest_replay>)
 set_tests_properties(visual_feature_track_ingest_replay PROPERTIES
-    LABELS "integration;navigation;replay;shadow-only;visual-feature-tracking")
+    LABELS "integration;navigation;replay;shadow-only;visual-feature-tracking"
+)

--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -1,11 +1,15 @@
-add_executable(test_visual_feature_track_manager test_visual_feature_track_manager.cpp)
+add_executable(test_visual_feature_track_manager
+    "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_manager.cpp"
+)
 target_link_libraries(test_visual_feature_track_manager PRIVATE
     drone_test_support
     Eigen3::Eigen
 )
 drone_register_gtest(test_visual_feature_track_manager "unit;navigation;visual-feature-tracking")
 
-add_executable(test_visual_feature_track_ingest test_visual_feature_track_ingest.cpp)
+add_executable(test_visual_feature_track_ingest
+    "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_ingest.cpp"
+)
 target_link_libraries(test_visual_feature_track_ingest PRIVATE
     drone_test_support
     ${DRONE_PHASE17_TEST_CORE}
@@ -13,7 +17,9 @@ target_link_libraries(test_visual_feature_track_ingest PRIVATE
 )
 drone_register_gtest(test_visual_feature_track_ingest "unit;navigation;shadow-only;visual-feature-tracking")
 
-add_executable(visual_feature_track_ingest_replay visual_feature_track_ingest_replay.cpp)
+add_executable(visual_feature_track_ingest_replay
+    "${CMAKE_CURRENT_LIST_DIR}/visual_feature_track_ingest_replay.cpp"
+)
 target_link_libraries(visual_feature_track_ingest_replay PRIVATE
     ${DRONE_PHASE17_TEST_CORE}
     Eigen3::Eigen

--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -1,3 +1,8 @@
+set(VISUAL_FEATURE_TRACK_TEST_CORE sensor_fusion_core)
+if(TARGET phase17_estimator_headless_core)
+    set(VISUAL_FEATURE_TRACK_TEST_CORE phase17_estimator_headless_core)
+endif()
+
 add_executable(test_visual_feature_track_manager
     "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_manager.cpp"
 )
@@ -12,7 +17,7 @@ add_executable(test_visual_feature_track_ingest
 )
 target_link_libraries(test_visual_feature_track_ingest PRIVATE
     drone_test_support
-    ${DRONE_PHASE17_TEST_CORE}
+    ${VISUAL_FEATURE_TRACK_TEST_CORE}
     Eigen3::Eigen
 )
 drone_register_gtest(test_visual_feature_track_ingest "unit;navigation;shadow-only;visual-feature-tracking")
@@ -21,7 +26,7 @@ add_executable(visual_feature_track_ingest_replay
     "${CMAKE_CURRENT_LIST_DIR}/visual_feature_track_ingest_replay.cpp"
 )
 target_link_libraries(visual_feature_track_ingest_replay PRIVATE
-    ${DRONE_PHASE17_TEST_CORE}
+    ${VISUAL_FEATURE_TRACK_TEST_CORE}
     Eigen3::Eigen
 )
 drone_apply_project_warnings(visual_feature_track_ingest_replay)

--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -1,0 +1,27 @@
+add_executable(test_visual_feature_track_manager test_visual_feature_track_manager.cpp)
+target_link_libraries(test_visual_feature_track_manager PRIVATE
+    drone_test_support
+    Eigen3::Eigen
+)
+drone_register_gtest(test_visual_feature_track_manager "unit;navigation;visual-feature-tracking")
+
+add_executable(test_visual_feature_track_ingest test_visual_feature_track_ingest.cpp)
+target_link_libraries(test_visual_feature_track_ingest PRIVATE
+    drone_test_support
+    ${DRONE_PHASE17_TEST_CORE}
+    Eigen3::Eigen
+)
+drone_register_gtest(test_visual_feature_track_ingest "unit;navigation;shadow-only;visual-feature-tracking")
+
+add_executable(visual_feature_track_ingest_replay visual_feature_track_ingest_replay.cpp)
+target_link_libraries(visual_feature_track_ingest_replay PRIVATE
+    ${DRONE_PHASE17_TEST_CORE}
+    Eigen3::Eigen
+)
+drone_apply_project_warnings(visual_feature_track_ingest_replay)
+drone_enable_coverage(visual_feature_track_ingest_replay)
+drone_enable_sanitizers(visual_feature_track_ingest_replay)
+drone_set_target_output_dirs(visual_feature_track_ingest_replay "tests" "tests" "tests")
+add_test(NAME visual_feature_track_ingest_replay COMMAND $<TARGET_FILE:visual_feature_track_ingest_replay>)
+set_tests_properties(visual_feature_track_ingest_replay PROPERTIES
+    LABELS "integration;navigation;replay;shadow-only;visual-feature-tracking")

--- a/tests/visual_feature_track_ingest_replay.cpp
+++ b/tests/visual_feature_track_ingest_replay.cpp
@@ -1,0 +1,132 @@
+#include "vio/EstimatorCoordinator.hpp"
+#include "vio/Phase17ESKFEstimator.hpp"
+#include "vio/VisualFeatureTrackManager.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace drone::vio;
+
+namespace {
+
+Eigen::Matrix3d intrinsics() {
+    Eigen::Matrix3d K = Eigen::Matrix3d::Zero();
+    K(0, 0) = 320.0;
+    K(1, 1) = 320.0;
+    K(0, 2) = 320.0;
+    K(1, 2) = 240.0;
+    K(2, 2) = 1.0;
+    return K;
+}
+
+PoseEstimate pose_at(double x) {
+    PoseEstimate pose;
+    pose.position = Eigen::Vector3d{x, 0.0, 0.0};
+    pose.orientation = Eigen::Quaterniond::Identity();
+    return pose;
+}
+
+struct ReplayResult {
+    std::vector<uint64_t> track_ids;
+    uint64_t shadow_submissions{0};
+    uint64_t shadow_processed{0};
+    bool queue_drained{false};
+    bool active_equivalent{false};
+};
+
+bool same_snapshot(const EstimatorStateSnapshot& lhs, const EstimatorStateSnapshot& rhs) {
+    return (lhs.position_m - rhs.position_m).norm() <= 1.0e-12 &&
+           (lhs.velocity_mps - rhs.velocity_mps).norm() <= 1.0e-12 &&
+           std::abs(std::abs(lhs.orientation.dot(rhs.orientation)) - 1.0) <= 1.0e-12 &&
+           std::abs(lhs.covariance.trace - rhs.covariance.trace) <= 1.0e-12;
+}
+
+ReplayResult run_once() {
+    VisualFeatureTrackConfig track_cfg;
+    track_cfg.minimum_baseline_m = 0.05;
+    track_cfg.minimum_parallax_deg = 0.1;
+    track_cfg.maximum_ray_gap_m = 0.5;
+    VisualFeatureTrackManager manager(track_cfg);
+
+    ShadowCoordinatorConfig shadow_cfg;
+    shadow_cfg.enabled = true;
+    shadow_cfg.start_worker_on_initialize = true;
+    shadow_cfg.queue_capacity = 32;
+
+    EstimatorCoordinator coordinator(
+        std::make_unique<EKFStateEstimatorAdapter>(EKFConfig{}, "ekf_active", "baseline"),
+        std::make_unique<Phase17StateEstimatorAdapter>(EKFConfig{}, "eskf_shadow", "hardened"),
+        shadow_cfg);
+    coordinator.initialize();
+    if (!coordinator.start()) {
+        return {};
+    }
+
+    const auto active_before = coordinator.active_snapshot();
+    const auto K = intrinsics();
+    const std::vector<Eigen::Vector2d> p0{{320.0, 240.0}, {340.0, 240.0}, {300.0, 240.0}};
+    const std::vector<Eigen::Vector2d> p1{{312.0, 240.0}, {332.0, 240.0}, {292.0, 240.0}};
+    const std::vector<Eigen::Vector2d> p2{{304.0, 240.0}, {324.0, 240.0}, {284.0, 240.0}};
+
+    ReplayResult result;
+    const auto submit_batch = [&](const VisualFeatureTrackBatch& batch, double timestamp,
+                                  uint64_t sequence) {
+        VisualFeatureMeasurementPayload payload;
+        payload.K = K;
+        for (const auto& feature : batch.features) {
+            result.track_ids.push_back(feature.track_id);
+            payload.z_pixels.push_back(feature.pixel);
+            payload.p_world.push_back(feature.world_point);
+        }
+        if (payload.z_pixels.empty()) {
+            return false;
+        }
+        return coordinator.submit_shadow_measurement(make_visual_features_envelope(
+                   payload, MeasurementStamp{timestamp, sequence})) ==
+               EstimatorOperationResult::Accepted;
+    };
+
+    const auto first = manager.update(p0, p1, pose_at(0.0), pose_at(0.10), K);
+    const auto second = manager.update(p1, p2, pose_at(0.10), pose_at(0.20), K);
+    if (!submit_batch(first, 0.10, 1u) || !submit_batch(second, 0.20, 2u)) {
+        coordinator.stop();
+        return {};
+    }
+
+    coordinator.flush_shadow();
+    const auto active_after = coordinator.active_snapshot();
+    const auto diagnostics = coordinator.diagnostics();
+    result.shadow_submissions = diagnostics.shadow_only_submission_count;
+    result.shadow_processed = diagnostics.shadow_processed_count;
+    result.queue_drained = coordinator.queue_depth() == 0u;
+    result.active_equivalent = same_snapshot(active_before, active_after);
+    coordinator.stop();
+    return result;
+}
+
+} // namespace
+
+int main() {
+    const auto first = run_once();
+    const auto second = run_once();
+
+    const bool deterministic = !first.track_ids.empty() && first.track_ids == second.track_ids &&
+                               first.shadow_submissions == second.shadow_submissions &&
+                               first.shadow_processed == second.shadow_processed;
+    const bool authority_preserved = first.active_equivalent && second.active_equivalent;
+    const bool shadow_path_ok = first.shadow_submissions == 2u && second.shadow_submissions == 2u &&
+                                first.shadow_processed >= 2u && second.shadow_processed >= 2u &&
+                                first.queue_drained && second.queue_drained;
+
+    std::cout << "deterministic=" << (deterministic ? "true" : "false") << '\n';
+    std::cout << "active_equivalent=" << (authority_preserved ? "true" : "false") << '\n';
+    std::cout << "shadow_path_ok=" << (shadow_path_ok ? "true" : "false") << '\n';
+    std::cout << "track_samples=" << first.track_ids.size() << '\n';
+    std::cout << "shadow_submissions=" << first.shadow_submissions << '\n';
+    std::cout << "shadow_processed=" << first.shadow_processed << '\n';
+
+    return deterministic && authority_preserved && shadow_path_ok ? 0 : 1;
+}


### PR DESCRIPTION
Implements deterministic real optical-flow feature tracking and shadow-only MSCKF ingest while preserving active estimator authority.

Scope:
- persistent feature IDs across optical-flow frames
- fail-closed two-view initialization with baseline/parallax/depth/ray-gap checks
- real frontend inlier correspondences exported from VIO frontend
- initialized feature tracks converted to VisualFeatures payloads
- VisualFeatures submitted only through EstimatorCoordinator::submit_shadow_measurement
- simulation placeholder remains pose-only and does not fabricate production feature tracks
- runtime telemetry for track count, initialization, geometry rejection, and shadow submissions
- deterministic manager/unit coverage
- shadow-only authority preservation coverage
- deterministic ingest replay
- dedicated CMake validation target registration

Acceptance gate: full hosted CI must pass before merge.