### PR TITLE
Add fail-closed visual estimator promotion readiness gate

### DIFF
--- a/docs/visual-feature-active-promotion-readiness/README.md
+++ b/docs/visual-feature-active-promotion-readiness/README.md
@@ -1,0 +1,50 @@
+# Visual Feature Active-Promotion Readiness
+
+## Purpose
+
+This phase adds a fail-closed, read-only readiness gate for evaluating whether the shadow estimator has accumulated enough healthy evidence to be considered for a future authority-promotion phase.
+
+This work does **not** switch estimator authority and does **not** route `VisualFeatures` measurements into the active estimator. The active baseline remains authoritative.
+
+## Readiness evidence
+
+`EstimatorPromotionReadiness.hpp` evaluates existing `CoordinatorDiagnostics` and blocks promotion unless all configured requirements are satisfied:
+
+- shadow estimator enabled
+- shadow worker running
+- lifecycle state is `Running`
+- active estimator healthy
+- shadow estimator healthy
+- minimum valid comparison count reached
+- latest comparison valid
+- queue drops remain within policy (zero by default)
+- stale measurements remain within policy (zero by default)
+- shadow processing failures remain within policy (zero by default)
+- active/shadow position delta remains bounded
+- active/shadow velocity delta remains bounded
+- active/shadow orientation delta remains bounded
+- absolute covariance-trace delta remains bounded
+
+Default comparison thresholds are intentionally conservative and are configuration values, not flight-validation claims.
+
+## Safety boundary
+
+The evaluator is observational only. It returns `PromotionReadinessResult` with a single explicit blocking reason. No code in this phase can promote, swap, or mutate estimator authority.
+
+Future authority promotion must remain a separate phase with its own explicit rollback path, deterministic replay evidence, sanitizer matrix, HIL acceptance criteria, and operator-visible state transition.
+
+## Tests
+
+Coverage is added to the existing shadow-only test target for:
+
+- healthy bounded evidence becoming ready
+- insufficient comparison evidence failing closed
+- queue drops failing closed
+- configured pose-delta violations failing closed
+- absolute covariance-delta enforcement
+
+## Status
+
+Implementation phase: in progress on `visual-feature-active-promotion-readiness`.
+
+Physical flight readiness remains unchanged: **not flight validated**.

--- a/include/vio/EstimatorPromotionReadiness.hpp
+++ b/include/vio/EstimatorPromotionReadiness.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "vio/EstimatorCoordinator.hpp"
+
+#include <cstdint>
+#include <string_view>
+
+namespace drone::vio {
+
+enum class PromotionBlockReason : uint8_t {
+    None = 0,
+    ShadowDisabled,
+    WorkerNotRunning,
+    LifecycleNotRunning,
+    ActiveUnhealthy,
+    ShadowUnhealthy,
+    InsufficientComparisons,
+    InvalidComparison,
+    QueueDropsObserved,
+    StaleMeasurementsObserved,
+    ShadowProcessingFailuresObserved,
+    PositionDeltaExceeded,
+    VelocityDeltaExceeded,
+    OrientationDeltaExceeded,
+    CovarianceTraceDeltaExceeded,
+};
+
+struct PromotionReadinessConfig {
+    uint64_t minimum_valid_comparisons{100};
+    double max_position_delta_m{0.25};
+    double max_velocity_delta_mps{0.35};
+    double max_orientation_delta_deg{5.0};
+    double max_abs_covariance_trace_delta{1.0};
+    bool require_zero_queue_drops{true};
+    bool require_zero_stale_measurements{true};
+    bool require_zero_processing_failures{true};
+};
+
+struct PromotionReadinessResult {
+    bool ready{false};
+    PromotionBlockReason reason{PromotionBlockReason::ShadowDisabled};
+};
+
+[[nodiscard]] constexpr std::string_view to_string(PromotionBlockReason reason) {
+    switch (reason) {
+    case PromotionBlockReason::None:
+        return "ready";
+    case PromotionBlockReason::ShadowDisabled:
+        return "shadow_disabled";
+    case PromotionBlockReason::WorkerNotRunning:
+        return "worker_not_running";
+    case PromotionBlockReason::LifecycleNotRunning:
+        return "lifecycle_not_running";
+    case PromotionBlockReason::ActiveUnhealthy:
+        return "active_unhealthy";
+    case PromotionBlockReason::ShadowUnhealthy:
+        return "shadow_unhealthy";
+    case PromotionBlockReason::InsufficientComparisons:
+        return "insufficient_comparisons";
+    case PromotionBlockReason::InvalidComparison:
+        return "invalid_comparison";
+    case PromotionBlockReason::QueueDropsObserved:
+        return "queue_drops_observed";
+    case PromotionBlockReason::StaleMeasurementsObserved:
+        return "stale_measurements_observed";
+    case PromotionBlockReason::ShadowProcessingFailuresObserved:
+        return "shadow_processing_failures_observed";
+    case PromotionBlockReason::PositionDeltaExceeded:
+        return "position_delta_exceeded";
+    case PromotionBlockReason::VelocityDeltaExceeded:
+        return "velocity_delta_exceeded";
+    case PromotionBlockReason::OrientationDeltaExceeded:
+        return "orientation_delta_exceeded";
+    case PromotionBlockReason::CovarianceTraceDeltaExceeded:
+        return "covariance_trace_delta_exceeded";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] inline PromotionReadinessResult
+assess_promotion_readiness(const CoordinatorDiagnostics& diagnostics,
+                           const PromotionReadinessConfig& cfg = {}) {
+    auto blocked = [](PromotionBlockReason reason) {
+        return PromotionReadinessResult{false, reason};
+    };
+
+    if (!diagnostics.shadow_enabled) {
+        return blocked(PromotionBlockReason::ShadowDisabled);
+    }
+    if (!diagnostics.worker_running) {
+        return blocked(PromotionBlockReason::WorkerNotRunning);
+    }
+    if (diagnostics.lifecycle_state != ShadowLifecycleState::Running) {
+        return blocked(PromotionBlockReason::LifecycleNotRunning);
+    }
+    if (diagnostics.active_health != EstimatorHealth::Healthy) {
+        return blocked(PromotionBlockReason::ActiveUnhealthy);
+    }
+    if (diagnostics.shadow_health != EstimatorHealth::Healthy) {
+        return blocked(PromotionBlockReason::ShadowUnhealthy);
+    }
+    if (diagnostics.valid_comparison_count < cfg.minimum_valid_comparisons) {
+        return blocked(PromotionBlockReason::InsufficientComparisons);
+    }
+    if (!diagnostics.last_comparison.valid) {
+        return blocked(PromotionBlockReason::InvalidComparison);
+    }
+    if (cfg.require_zero_queue_drops && diagnostics.queue.dropped_count != 0u) {
+        return blocked(PromotionBlockReason::QueueDropsObserved);
+    }
+    if (cfg.require_zero_stale_measurements && diagnostics.queue.stale_count != 0u) {
+        return blocked(PromotionBlockReason::StaleMeasurementsObserved);
+    }
+    if (cfg.require_zero_processing_failures && diagnostics.queue.processing_failure_count != 0u) {
+        return blocked(PromotionBlockReason::ShadowProcessingFailuresObserved);
+    }
+    if (diagnostics.last_comparison.position_delta_norm_m > cfg.max_position_delta_m) {
+        return blocked(PromotionBlockReason::PositionDeltaExceeded);
+    }
+    if (diagnostics.last_comparison.velocity_delta_norm_mps > cfg.max_velocity_delta_mps) {
+        return blocked(PromotionBlockReason::VelocityDeltaExceeded);
+    }
+    if (diagnostics.last_comparison.orientation_delta_deg > cfg.max_orientation_delta_deg) {
+        return blocked(PromotionBlockReason::OrientationDeltaExceeded);
+    }
+    const double covariance_delta = diagnostics.last_comparison.covariance_trace_delta;
+    if (covariance_delta > cfg.max_abs_covariance_trace_delta ||
+        covariance_delta < -cfg.max_abs_covariance_trace_delta) {
+        return blocked(PromotionBlockReason::CovarianceTraceDeltaExceeded);
+    }
+
+    return {true, PromotionBlockReason::None};
+}
+
+} // namespace drone::vio

--- a/tests/test_shadow_only_measurement.cpp
+++ b/tests/test_shadow_only_measurement.cpp
@@ -2,6 +2,7 @@
 
 #include "vio/EKFStateEstimatorAdapter.hpp"
 #include "vio/EstimatorCoordinator.hpp"
+#include "vio/EstimatorPromotionReadiness.hpp"
 
 #include <atomic>
 #include <limits>
@@ -89,6 +90,22 @@ MeasurementEnvelope valid_feature_envelope() {
     return make_visual_features_envelope(payload, MeasurementStamp{0.01, 1u});
 }
 
+CoordinatorDiagnostics promotion_ready_diagnostics() {
+    CoordinatorDiagnostics diagnostics;
+    diagnostics.shadow_enabled = true;
+    diagnostics.worker_running = true;
+    diagnostics.lifecycle_state = ShadowLifecycleState::Running;
+    diagnostics.active_health = EstimatorHealth::Healthy;
+    diagnostics.shadow_health = EstimatorHealth::Healthy;
+    diagnostics.valid_comparison_count = 250;
+    diagnostics.last_comparison.valid = true;
+    diagnostics.last_comparison.position_delta_norm_m = 0.05;
+    diagnostics.last_comparison.velocity_delta_norm_mps = 0.06;
+    diagnostics.last_comparison.orientation_delta_deg = 0.5;
+    diagnostics.last_comparison.covariance_trace_delta = 0.1;
+    return diagnostics;
+}
+
 } // namespace
 
 TEST(ShadowOnlyMeasurement, FeatureSubmissionNeverTouchesActiveEstimator) {
@@ -156,4 +173,47 @@ TEST(ShadowOnlyMeasurement, DisabledShadowFailsClosedWithoutActiveMutation) {
     EXPECT_EQ(diagnostics.shadow_only_rejected_count, 1u);
     EXPECT_EQ(diagnostics.active_processed_count, 0u);
     EXPECT_NEAR((active_after.position_m - active_before.position_m).norm(), 0.0, 1.0e-15);
+}
+
+TEST(ShadowPromotionReadiness, HealthyBoundedComparisonWindowCanBecomeReady) {
+    const auto result = assess_promotion_readiness(promotion_ready_diagnostics());
+    EXPECT_TRUE(result.ready);
+    EXPECT_EQ(result.reason, PromotionBlockReason::None);
+    EXPECT_EQ(to_string(result.reason), "ready");
+}
+
+TEST(ShadowPromotionReadiness, FailsClosedWhenEvidenceIsInsufficient) {
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.valid_comparison_count = 99;
+
+    const auto result = assess_promotion_readiness(diagnostics);
+    EXPECT_FALSE(result.ready);
+    EXPECT_EQ(result.reason, PromotionBlockReason::InsufficientComparisons);
+}
+
+TEST(ShadowPromotionReadiness, FailsClosedOnQueueDrop) {
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.queue.dropped_count = 1;
+
+    const auto result = assess_promotion_readiness(diagnostics);
+    EXPECT_FALSE(result.ready);
+    EXPECT_EQ(result.reason, PromotionBlockReason::QueueDropsObserved);
+}
+
+TEST(ShadowPromotionReadiness, FailsClosedWhenComparisonExceedsConfiguredBound) {
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.last_comparison.position_delta_norm_m = 0.30;
+
+    const auto result = assess_promotion_readiness(diagnostics);
+    EXPECT_FALSE(result.ready);
+    EXPECT_EQ(result.reason, PromotionBlockReason::PositionDeltaExceeded);
+}
+
+TEST(ShadowPromotionReadiness, DoesNotTreatNegativeCovarianceDeltaAsUnbounded) {
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.last_comparison.covariance_trace_delta = -1.5;
+
+    const auto result = assess_promotion_readiness(diagnostics);
+    EXPECT_FALSE(result.ready);
+    EXPECT_EQ(result.reason, PromotionBlockReason::CovarianceTraceDeltaExceeded);
 }


### PR DESCRIPTION
## Summary

Continues the estimator-hardening track after merged PR #17.

Adds a read-only, fail-closed promotion-readiness evaluator for the shadow estimator. This phase does **not** switch estimator authority and does **not** send visual-feature measurements to the active estimator.

### Changes

- add `EstimatorPromotionReadiness.hpp`
- evaluate active/shadow health, lifecycle state, comparison count, queue integrity, processing failures, pose deltas, and covariance-trace delta
- return an explicit first blocking reason
- add focused coverage to the existing shadow-only test target
- document the safety boundary and future authority-promotion requirements

### Safety boundary

The active baseline remains authoritative. This PR only computes readiness evidence; it cannot promote, swap, or mutate estimator authority.

### Validation requested

- existing CMake configure/build lanes
- `test_shadow_only_measurement`
- compiler warning-as-error lanes
- sanitizer/static-analysis lanes where applicable
