### PR TITLE
Estimator Authority Promotion & Rollback

### DIFF
--- a/docs/estimator-authority-promotion-rollback/README.md
+++ b/docs/estimator-authority-promotion-rollback/README.md
@@ -1,1 +1,47 @@
 # Estimator Authority Promotion & Rollback
+
+## Purpose
+
+This work introduces a fail-closed authority-promotion controller for the existing active/shadow estimator topology.
+
+The processing topology remains unchanged: the baseline estimator continues to receive the normal measurement stream and the advanced estimator continues to run through the existing shadow worker plus shadow-only visual-feature ingest. Promotion changes only which already-running estimator snapshot may eventually be exposed as authoritative output after an explicit readiness check.
+
+## Safety invariants
+
+- baseline authority is the default after construction, initialize, and reset
+- promotion is never automatic
+- promotion requires an explicit request and a passing `EstimatorPromotionReadiness` result
+- a reset-generation mismatch rejects promotion
+- rollback to baseline is always explicit and idempotent
+- promotion does not swap estimator objects or stop the baseline estimator
+- promotion does not re-route shadow-only feature measurements into the baseline estimator
+- failed promotion leaves authority unchanged
+- reset invalidates any promoted authority state and returns the controller to baseline
+
+## Initial implementation
+
+`EstimatorAuthorityController.hpp` provides a deterministic state machine with:
+
+- baseline and advanced-shadow authority states
+- fail-closed promotion using the existing readiness gate
+- reset-generation binding
+- explicit rollback
+- idempotent repeated promotion/rollback requests
+- promotion/rollback counters for future diagnostics
+
+The controller is intentionally not yet wired into `EstimatorCoordinator::active_snapshot()` or `active_pose()`. That integration is the next gate and must prove atomic output selection, reset rollback, post-promotion degradation rollback behavior, and active-baseline continuity before authority can change in runtime output.
+
+## Validation required before runtime integration
+
+- promotion-ready evidence promotes exactly once
+- insufficient readiness cannot change authority
+- generation mismatch cannot change authority
+- rollback restores baseline authority
+- reset restores baseline authority
+- repeated promotion/rollback calls are deterministic
+- coordinator integration preserves the existing processing topology
+- shadow-only `VisualFeatures` routing remains unchanged
+- deterministic replay proves promotion and rollback output transitions
+- compiler, warnings-as-errors, formatting, static-analysis, ASan/UBSan, TSan, and project-owned race checks pass
+
+No HIL, flight activation, or automatic estimator switching is included in this work.

--- a/include/vio/EstimatorAuthorityController.hpp
+++ b/include/vio/EstimatorAuthorityController.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "vio/EstimatorPromotionReadiness.hpp"
+
+#include <cstdint>
+#include <string_view>
+
+namespace drone::vio {
+
+enum class EstimatorAuthority : uint8_t {
+    Baseline = 0,
+    AdvancedShadow,
+};
+
+enum class AuthorityTransitionStatus : uint8_t {
+    NoOp = 0,
+    Promoted,
+    RolledBack,
+    RejectedNotReady,
+    RejectedGenerationMismatch,
+};
+
+struct AuthorityTransitionResult {
+    AuthorityTransitionStatus status{AuthorityTransitionStatus::NoOp};
+    EstimatorAuthority previous{EstimatorAuthority::Baseline};
+    EstimatorAuthority current{EstimatorAuthority::Baseline};
+    PromotionBlockReason readiness_reason{PromotionBlockReason::None};
+};
+
+[[nodiscard]] constexpr std::string_view to_string(EstimatorAuthority authority) {
+    switch (authority) {
+    case EstimatorAuthority::Baseline:
+        return "baseline";
+    case EstimatorAuthority::AdvancedShadow:
+        return "advanced_shadow";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] constexpr std::string_view to_string(AuthorityTransitionStatus status) {
+    switch (status) {
+    case AuthorityTransitionStatus::NoOp:
+        return "no_op";
+    case AuthorityTransitionStatus::Promoted:
+        return "promoted";
+    case AuthorityTransitionStatus::RolledBack:
+        return "rolled_back";
+    case AuthorityTransitionStatus::RejectedNotReady:
+        return "rejected_not_ready";
+    case AuthorityTransitionStatus::RejectedGenerationMismatch:
+        return "rejected_generation_mismatch";
+    }
+    return "unknown";
+}
+
+class EstimatorAuthorityController {
+public:
+    void reset(uint64_t generation) {
+        authority_ = EstimatorAuthority::Baseline;
+        generation_ = generation;
+    }
+
+    [[nodiscard]] AuthorityTransitionResult
+    request_promotion(const CoordinatorDiagnostics& diagnostics,
+                      const PromotionReadinessConfig& readiness_cfg = {}) {
+        const auto previous = authority_;
+        if (diagnostics.reset_generation != generation_) {
+            return {AuthorityTransitionStatus::RejectedGenerationMismatch, previous, authority_,
+                    PromotionBlockReason::None};
+        }
+
+        const auto readiness = assess_promotion_readiness(diagnostics, readiness_cfg);
+        if (!readiness.ready) {
+            return {AuthorityTransitionStatus::RejectedNotReady, previous, authority_,
+                    readiness.reason};
+        }
+
+        if (authority_ == EstimatorAuthority::AdvancedShadow) {
+            return {AuthorityTransitionStatus::NoOp, previous, authority_,
+                    PromotionBlockReason::None};
+        }
+
+        authority_ = EstimatorAuthority::AdvancedShadow;
+        ++promotion_count_;
+        return {AuthorityTransitionStatus::Promoted, previous, authority_, PromotionBlockReason::None};
+    }
+
+    [[nodiscard]] AuthorityTransitionResult rollback_to_baseline(uint64_t generation) {
+        const auto previous = authority_;
+        if (generation != generation_) {
+            return {AuthorityTransitionStatus::RejectedGenerationMismatch, previous, authority_,
+                    PromotionBlockReason::None};
+        }
+        if (authority_ == EstimatorAuthority::Baseline) {
+            return {AuthorityTransitionStatus::NoOp, previous, authority_,
+                    PromotionBlockReason::None};
+        }
+
+        authority_ = EstimatorAuthority::Baseline;
+        ++rollback_count_;
+        return {AuthorityTransitionStatus::RolledBack, previous, authority_,
+                PromotionBlockReason::None};
+    }
+
+    [[nodiscard]] EstimatorAuthority authority() const { return authority_; }
+    [[nodiscard]] uint64_t generation() const { return generation_; }
+    [[nodiscard]] uint64_t promotion_count() const { return promotion_count_; }
+    [[nodiscard]] uint64_t rollback_count() const { return rollback_count_; }
+
+private:
+    EstimatorAuthority authority_{EstimatorAuthority::Baseline};
+    uint64_t generation_{0};
+    uint64_t promotion_count_{0};
+    uint64_t rollback_count_{0};
+};
+
+} // namespace drone::vio

--- a/tests/test_shadow_only_measurement.cpp
+++ b/tests/test_shadow_only_measurement.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "vio/EKFStateEstimatorAdapter.hpp"
+#include "vio/EstimatorAuthorityController.hpp"
 #include "vio/EstimatorCoordinator.hpp"
 #include "vio/EstimatorPromotionReadiness.hpp"
 
@@ -216,4 +217,79 @@ TEST(ShadowPromotionReadiness, DoesNotTreatNegativeCovarianceDeltaAsUnbounded) {
     const auto result = assess_promotion_readiness(diagnostics);
     EXPECT_FALSE(result.ready);
     EXPECT_EQ(result.reason, PromotionBlockReason::CovarianceTraceDeltaExceeded);
+}
+
+TEST(EstimatorAuthorityController, PromotionRequiresReadyEvidenceAndMatchingGeneration) {
+    EstimatorAuthorityController controller;
+    controller.reset(7u);
+
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.reset_generation = 7u;
+    const auto result = controller.request_promotion(diagnostics);
+
+    EXPECT_EQ(result.status, AuthorityTransitionStatus::Promoted);
+    EXPECT_EQ(result.previous, EstimatorAuthority::Baseline);
+    EXPECT_EQ(result.current, EstimatorAuthority::AdvancedShadow);
+    EXPECT_EQ(controller.authority(), EstimatorAuthority::AdvancedShadow);
+    EXPECT_EQ(controller.promotion_count(), 1u);
+}
+
+TEST(EstimatorAuthorityController, NotReadyEvidenceCannotChangeAuthority) {
+    EstimatorAuthorityController controller;
+    controller.reset(3u);
+
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.reset_generation = 3u;
+    diagnostics.queue.dropped_count = 1u;
+    const auto result = controller.request_promotion(diagnostics);
+
+    EXPECT_EQ(result.status, AuthorityTransitionStatus::RejectedNotReady);
+    EXPECT_EQ(result.readiness_reason, PromotionBlockReason::QueueDropsObserved);
+    EXPECT_EQ(controller.authority(), EstimatorAuthority::Baseline);
+    EXPECT_EQ(controller.promotion_count(), 0u);
+}
+
+TEST(EstimatorAuthorityController, GenerationMismatchFailsClosed) {
+    EstimatorAuthorityController controller;
+    controller.reset(10u);
+
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.reset_generation = 11u;
+    const auto result = controller.request_promotion(diagnostics);
+
+    EXPECT_EQ(result.status, AuthorityTransitionStatus::RejectedGenerationMismatch);
+    EXPECT_EQ(controller.authority(), EstimatorAuthority::Baseline);
+}
+
+TEST(EstimatorAuthorityController, RollbackIsExplicitAndIdempotent) {
+    EstimatorAuthorityController controller;
+    controller.reset(5u);
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.reset_generation = 5u;
+    ASSERT_EQ(controller.request_promotion(diagnostics).status,
+              AuthorityTransitionStatus::Promoted);
+
+    const auto first = controller.rollback_to_baseline(5u);
+    const auto second = controller.rollback_to_baseline(5u);
+
+    EXPECT_EQ(first.status, AuthorityTransitionStatus::RolledBack);
+    EXPECT_EQ(second.status, AuthorityTransitionStatus::NoOp);
+    EXPECT_EQ(controller.authority(), EstimatorAuthority::Baseline);
+    EXPECT_EQ(controller.rollback_count(), 1u);
+}
+
+TEST(EstimatorAuthorityController, ResetAlwaysRestoresBaselineAuthority) {
+    EstimatorAuthorityController controller;
+    controller.reset(1u);
+    auto diagnostics = promotion_ready_diagnostics();
+    diagnostics.reset_generation = 1u;
+    ASSERT_EQ(controller.request_promotion(diagnostics).status,
+              AuthorityTransitionStatus::Promoted);
+
+    controller.reset(2u);
+
+    EXPECT_EQ(controller.authority(), EstimatorAuthority::Baseline);
+    EXPECT_EQ(controller.generation(), 2u);
+    EXPECT_EQ(controller.rollback_to_baseline(1u).status,
+              AuthorityTransitionStatus::RejectedGenerationMismatch);
 }


### PR DESCRIPTION
## Scope

Starts the next estimator-hardening work after the merged promotion-readiness gate.

This branch adds the fail-closed authority state machine first, without yet changing runtime output authority.

### Implemented
- baseline vs advanced-shadow authority states
- explicit promotion request using the existing readiness evaluator
- reset-generation binding to reject stale promotion requests
- explicit idempotent rollback to baseline
- promotion/rollback counters
- focused tests for ready promotion, readiness rejection, generation mismatch, rollback, and reset behavior
- safety-boundary documentation

### Safety boundary
- no automatic promotion
- no estimator object swapping
- no flight activation
- no change to shadow-only VisualFeatures routing
- runtime `active_snapshot()` / `active_pose()` still use the baseline estimator until the next integration gate is validated

### Next gate
Integrate authority selection into EstimatorCoordinator with atomic output selection, explicit rollback, reset fallback, post-promotion health monitoring, deterministic replay, and full compiler/static-analysis/sanitizer evidence.