### PR TITLE
Visual Estimator Soak Validation

### DIFF
--- a/docs/visual-estimator-soak-validation/README.md
+++ b/docs/visual-estimator-soak-validation/README.md
@@ -1,0 +1,15 @@
+# Visual Estimator Soak Validation
+
+This work item extends the existing point-in-time promotion-readiness check into sustained readiness evidence for the shadow visual estimator.
+
+## Safety boundary
+
+- The active estimator remains authoritative.
+- The soak monitor is read-only and cannot switch estimators.
+- Any blocked readiness sample fails closed.
+- Readiness progress resets when configured to do so.
+- Queue drops, stale measurements, processing failures, health regressions, invalid comparisons, and divergence remain blockers through the existing readiness evaluator.
+
+## Goal
+
+Require a configurable number of consecutive healthy readiness samples before reporting `sustained_ready=true`. This is evidence generation only; it is not authority promotion, flight activation, or estimator switching.

--- a/include/vio/EstimatorPromotionSoakMonitor.hpp
+++ b/include/vio/EstimatorPromotionSoakMonitor.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "vio/EstimatorPromotionReadiness.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace drone::vio {
+
+struct PromotionSoakConfig {
+    uint64_t minimum_ready_samples{500};
+    uint64_t maximum_consecutive_blocked_samples{0};
+    bool reset_progress_on_block{true};
+};
+
+struct PromotionSoakState {
+    uint64_t total_samples{0};
+    uint64_t ready_samples{0};
+    uint64_t consecutive_ready_samples{0};
+    uint64_t consecutive_blocked_samples{0};
+    uint64_t reset_count{0};
+    PromotionBlockReason last_block_reason{PromotionBlockReason::ShadowDisabled};
+    bool sustained_ready{false};
+};
+
+class PromotionSoakMonitor {
+public:
+    explicit PromotionSoakMonitor(PromotionSoakConfig cfg = {}) : cfg_(cfg) {}
+
+    [[nodiscard]] const PromotionSoakState& observe(const PromotionReadinessResult& sample) {
+        ++state_.total_samples;
+        if (sample.ready) {
+            ++state_.ready_samples;
+            ++state_.consecutive_ready_samples;
+            state_.consecutive_blocked_samples = 0;
+            state_.last_block_reason = PromotionBlockReason::None;
+        } else {
+            state_.last_block_reason = sample.reason;
+            ++state_.consecutive_blocked_samples;
+            if (cfg_.reset_progress_on_block) {
+                if (state_.consecutive_ready_samples != 0u) {
+                    ++state_.reset_count;
+                }
+                state_.consecutive_ready_samples = 0;
+            }
+        }
+
+        const bool blocked_limit_ok =
+            state_.consecutive_blocked_samples <= cfg_.maximum_consecutive_blocked_samples;
+        state_.sustained_ready = blocked_limit_ok &&
+            state_.consecutive_ready_samples >= cfg_.minimum_ready_samples;
+        return state_;
+    }
+
+    [[nodiscard]] const PromotionSoakState& observe(const CoordinatorDiagnostics& diagnostics,
+                                                    const PromotionReadinessConfig& readiness_cfg = {}) {
+        return observe(assess_promotion_readiness(diagnostics, readiness_cfg));
+    }
+
+    void reset() { state_ = {}; }
+
+    [[nodiscard]] const PromotionSoakState& state() const { return state_; }
+    [[nodiscard]] const PromotionSoakConfig& config() const { return cfg_; }
+
+private:
+    PromotionSoakConfig cfg_{};
+    PromotionSoakState state_{};
+};
+
+} // namespace drone::vio

--- a/tests/test_shadow_only_measurement.cpp
+++ b/tests/test_shadow_only_measurement.cpp
@@ -3,6 +3,7 @@
 #include "vio/EKFStateEstimatorAdapter.hpp"
 #include "vio/EstimatorCoordinator.hpp"
 #include "vio/EstimatorPromotionReadiness.hpp"
+#include "vio/EstimatorPromotionSoakMonitor.hpp"
 
 #include <atomic>
 #include <limits>
@@ -216,4 +217,63 @@ TEST(ShadowPromotionReadiness, DoesNotTreatNegativeCovarianceDeltaAsUnbounded) {
     const auto result = assess_promotion_readiness(diagnostics);
     EXPECT_FALSE(result.ready);
     EXPECT_EQ(result.reason, PromotionBlockReason::CovarianceTraceDeltaExceeded);
+}
+
+TEST(ShadowPromotionSoak, RequiresConsecutiveReadySamples) {
+    PromotionSoakMonitor monitor(PromotionSoakConfig{3, 0, true});
+    const auto ready = assess_promotion_readiness(promotion_ready_diagnostics());
+
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    const auto& state = monitor.observe(ready);
+    EXPECT_TRUE(state.sustained_ready);
+    EXPECT_EQ(state.consecutive_ready_samples, 3u);
+    EXPECT_EQ(state.ready_samples, 3u);
+}
+
+TEST(ShadowPromotionSoak, BlockedSampleResetsReadinessProgress) {
+    PromotionSoakMonitor monitor(PromotionSoakConfig{3, 0, true});
+    const auto ready = assess_promotion_readiness(promotion_ready_diagnostics());
+    auto blocked_diagnostics = promotion_ready_diagnostics();
+    blocked_diagnostics.queue.dropped_count = 1;
+    const auto blocked = assess_promotion_readiness(blocked_diagnostics);
+
+    monitor.observe(ready);
+    monitor.observe(ready);
+    const auto& blocked_state = monitor.observe(blocked);
+    EXPECT_FALSE(blocked_state.sustained_ready);
+    EXPECT_EQ(blocked_state.consecutive_ready_samples, 0u);
+    EXPECT_EQ(blocked_state.reset_count, 1u);
+    EXPECT_EQ(blocked_state.last_block_reason, PromotionBlockReason::QueueDropsObserved);
+
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    EXPECT_TRUE(monitor.observe(ready).sustained_ready);
+}
+
+TEST(ShadowPromotionSoak, DiagnosticsPathUsesExistingFailClosedReadinessRules) {
+    PromotionSoakMonitor monitor(PromotionSoakConfig{2, 0, true});
+    auto diagnostics = promotion_ready_diagnostics();
+
+    EXPECT_FALSE(monitor.observe(diagnostics).sustained_ready);
+    EXPECT_TRUE(monitor.observe(diagnostics).sustained_ready);
+
+    diagnostics.shadow_health = EstimatorHealth::Degraded;
+    const auto& state = monitor.observe(diagnostics);
+    EXPECT_FALSE(state.sustained_ready);
+    EXPECT_EQ(state.last_block_reason, PromotionBlockReason::ShadowUnhealthy);
+}
+
+TEST(ShadowPromotionSoak, ResetClearsAllAccumulatedEvidence) {
+    PromotionSoakMonitor monitor(PromotionSoakConfig{2, 0, true});
+    const auto ready = assess_promotion_readiness(promotion_ready_diagnostics());
+    monitor.observe(ready);
+    monitor.observe(ready);
+    ASSERT_TRUE(monitor.state().sustained_ready);
+
+    monitor.reset();
+    EXPECT_EQ(monitor.state().total_samples, 0u);
+    EXPECT_EQ(monitor.state().ready_samples, 0u);
+    EXPECT_EQ(monitor.state().consecutive_ready_samples, 0u);
+    EXPECT_FALSE(monitor.state().sustained_ready);
 }


### PR DESCRIPTION
Adds sustained, fail-closed readiness evidence on top of the existing point-in-time visual estimator promotion gate.

Implemented:
- consecutive-ready soak monitor
- configurable minimum ready samples
- progress reset on any blocked sample
- preservation of existing blockers for health, queue drops, stale measurements, processing failures, invalid comparisons and estimator divergence
- resettable evidence state
- focused unit coverage inside the existing shadow-only test target
- design/safety documentation

Safety boundary:
- active estimator remains authoritative
- no estimator switching
- no authority promotion
- no flight activation
- this work only accumulates promotion-readiness evidence

Validation gate before merge:
- existing shadow-only tests pass
- GCC/Clang/MSVC and warnings-as-errors pass
- clang-format/clang-tidy pass
- ASan/UBSan/TSan pass with no project-owned findings
- regressions remain green