### PR TITLE
Fix visual estimator soak validation CI

### DIFF
--- a/tests/test_shadow_only_measurement.cpp
+++ b/tests/test_shadow_only_measurement.cpp
@@ -238,8 +238,8 @@ TEST(ShadowPromotionSoak, BlockedSampleResetsReadinessProgress) {
     blocked_diagnostics.queue.dropped_count = 1;
     const auto blocked = assess_promotion_readiness(blocked_diagnostics);
 
-    monitor.observe(ready);
-    monitor.observe(ready);
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
     const auto& blocked_state = monitor.observe(blocked);
     EXPECT_FALSE(blocked_state.sustained_ready);
     EXPECT_EQ(blocked_state.consecutive_ready_samples, 0u);
@@ -267,8 +267,8 @@ TEST(ShadowPromotionSoak, DiagnosticsPathUsesExistingFailClosedReadinessRules) {
 TEST(ShadowPromotionSoak, ResetClearsAllAccumulatedEvidence) {
     PromotionSoakMonitor monitor(PromotionSoakConfig{2, 0, true});
     const auto ready = assess_promotion_readiness(promotion_ready_diagnostics());
-    monitor.observe(ready);
-    monitor.observe(ready);
+    EXPECT_FALSE(monitor.observe(ready).sustained_ready);
+    EXPECT_TRUE(monitor.observe(ready).sustained_ready);
     ASSERT_TRUE(monitor.state().sustained_ready);
 
     monitor.reset();


### PR DESCRIPTION
## Summary

Follow-up to merged PR #22. This fixes CI failures introduced by the visual estimator soak validation tests without changing estimator behavior.

### Changes
- consume and assert all `[[nodiscard]]` `PromotionSoakMonitor::observe()` results in focused soak tests
- preserve the existing fail-closed readiness and sustained-soak semantics

### Safety / scope
- no estimator switching
- no automatic promotion
- no active-estimator authority change
- no flight activation
- validation/readiness observation only

### Validation
The hosted CI matrix is used to re-check GCC, Clang, MSVC, warnings-as-errors, clang-format, clang-tidy, sanitizers, regression tests, validators, and install-consumer coverage.