### PR TITLE
fix: restore v2.0.0 cross-platform builds

### DIFF
--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -1,3 +1,12 @@
+# This test fragment is included from the repository root after add_subdirectory(tests).
+# DRONE_PHASE17_TEST_CORE is selected inside the tests directory scope, so it is
+# not visible here. Resolve the globally-created target explicitly to preserve
+# the headless/TSan core when enabled and use the normal core otherwise.
+set(DRONE_VISUAL_FEATURE_TRACK_TEST_CORE sensor_fusion_core)
+if(TARGET phase17_estimator_headless_core)
+    set(DRONE_VISUAL_FEATURE_TRACK_TEST_CORE phase17_estimator_headless_core)
+endif()
+
 add_executable(test_visual_feature_track_manager
     "${CMAKE_CURRENT_LIST_DIR}/test_visual_feature_track_manager.cpp"
 )
@@ -22,7 +31,7 @@ add_executable(test_visual_feature_track_ingest
 )
 target_link_libraries(test_visual_feature_track_ingest PRIVATE
     drone_test_support
-    ${DRONE_PHASE17_TEST_CORE}
+    ${DRONE_VISUAL_FEATURE_TRACK_TEST_CORE}
     Eigen3::Eigen
 )
 drone_apply_project_warnings(test_visual_feature_track_ingest)
@@ -41,7 +50,7 @@ add_executable(visual_feature_track_ingest_replay
     "${CMAKE_CURRENT_LIST_DIR}/visual_feature_track_ingest_replay.cpp"
 )
 target_link_libraries(visual_feature_track_ingest_replay PRIVATE
-    ${DRONE_PHASE17_TEST_CORE}
+    ${DRONE_VISUAL_FEATURE_TRACK_TEST_CORE}
     Eigen3::Eigen
 )
 drone_apply_project_warnings(visual_feature_track_ingest_replay)


### PR DESCRIPTION
## Summary

Fixes the v2.0.0 build-stage failure caused by CMake directory-scope visibility for the Phase 17 estimator test core.

## Root cause

`DRONE_PHASE17_TEST_CORE` is selected inside `tests/CMakeLists.txt`, but `tests/visual_feature_track_ingest.cmake` is included later from the repository root. Normal CMake variables do not propagate from the `tests` subdirectory back to the parent scope, so the visual-feature ingest targets were created without the selected estimator core library. This produced unresolved estimator symbols across GCC, Clang, and MSVC builds.

## Fix

- Resolve the visual-feature test core locally in the root-included test fragment.
- Use `phase17_estimator_headless_core` when that target exists (headless/TSan mode).
- Fall back to `sensor_fusion_core` for normal builds.
- Keep existing estimator behavior and release scope unchanged.

## Validation scope

This PR is intended to restore the existing cross-platform CI build matrix. It does not add estimator authority promotion, rollback, flight-readiness claims, or physical-flight behavior.
