### PR TITLE
fix(localization): keep invalid TDOA fail-closed

### DIFF
--- a/src/localization/LocalizationFusion.cpp
+++ b/src/localization/LocalizationFusion.cpp
@@ -22,13 +22,16 @@ LocalizationFusionOutput LocalizationFusion::update(const LocalizationFusionInpu
 
     double confidence = std::clamp(input.vio_pose.localization_confidence, 0.0, 1.0);
     double tdoa_weight = 0.0;
+    double tdoa_conf = 0.0;
+    bool tdoa_valid = false;
 
     if (input.tdoa_solution.has_value()) {
         if (!input.tdoa_solution->position.array().isFinite().all() ||
             !std::isfinite(input.tdoa_solution->confidence)) {
             out.source = "invalid-tdoa-input";
         } else {
-            const double tdoa_conf = std::clamp(input.tdoa_solution->confidence, 0.0, 1.0);
+            tdoa_valid = true;
+            tdoa_conf = std::clamp(input.tdoa_solution->confidence, 0.0, 1.0);
             const double drift_bias = std::clamp(input.vio_pose.drift_m / 2.0, 0.0, 1.0);
             tdoa_weight = std::clamp((tdoa_conf * 0.55) + (drift_bias * 0.45), 0.0, 0.85);
             out.fused_position = (input.vio_pose.position * (1.0 - tdoa_weight)) +
@@ -49,9 +52,8 @@ LocalizationFusionOutput LocalizationFusion::update(const LocalizationFusionInpu
         confidence *= std::clamp(input.time_sync.confidence, 0.35, 1.0);
     }
     confidence *= std::clamp(0.65 + input.anchor_visibility_ratio * 0.35, 0.65, 1.0);
-    if (input.tdoa_solution.has_value() && input.time_sync.confidence >= 0.8 &&
-        input.anchor_visibility_ratio >= 0.5) {
-        const double tdoa_floor = (input.tdoa_solution->confidence * 0.55) +
+    if (tdoa_valid && input.time_sync.confidence >= 0.8 && input.anchor_visibility_ratio >= 0.5) {
+        const double tdoa_floor = (tdoa_conf * 0.55) +
                                   (std::clamp(input.anchor_visibility_ratio, 0.0, 1.0) * 0.25) +
                                   (std::clamp(input.time_sync.confidence, 0.0, 1.0) * 0.20);
         confidence = std::max(confidence, tdoa_floor);
@@ -71,9 +73,9 @@ LocalizationFusionOutput LocalizationFusion::update(const LocalizationFusionInpu
         out.degraded = true;
     }
 
-    if (out.lost && input.tdoa_solution.has_value()) {
+    if (out.lost && tdoa_valid) {
         out.source = "tdoa-recovery";
-    } else if (tdoa_weight > 0.35 && input.tdoa_solution.has_value()) {
+    } else if (tdoa_weight > 0.35 && tdoa_valid) {
         out.source = "vio-tdoa-fused";
     } else if (!input.camera_available) {
         out.source = "imu-dead-reckoning";

--- a/tests/test_navigation_intelligence.cpp
+++ b/tests/test_navigation_intelligence.cpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <limits>
 
 #include <opencv2/imgproc.hpp>
 
@@ -131,6 +132,56 @@ TEST(LocalizationFusion, PrefersTdoaWhenVioDriftIsHigh) {
     EXPECT_GT(output.tdoa_weight, 0.35);
     EXPECT_EQ(output.source, "vio-tdoa-fused");
     EXPECT_GT(output.confidence, 0.5);
+}
+
+TEST(LocalizationFusion, InvalidTdoaPositionCannotRaiseConfidence) {
+    localization::LocalizationFusion fusion;
+    localization::LocalizationFusionInput input;
+    input.vio_pose.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+    input.vio_pose.drift_m = 2.0;
+    input.vio_pose.localization_confidence = 0.20;
+    input.camera_available = false;
+    input.anchor_visibility_ratio = 1.0;
+    input.time_sync.confidence = 1.0;
+    input.time_sync.synchronized = true;
+
+    localization::TDOALocalizer::Solution tdoa_solution;
+    tdoa_solution.position = Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    tdoa_solution.confidence = 1.0;
+    input.tdoa_solution = tdoa_solution;
+
+    const auto output = fusion.update(input);
+    EXPECT_DOUBLE_EQ(output.tdoa_weight, 0.0);
+    EXPECT_TRUE(output.fused_position.isApprox(input.vio_pose.position));
+    EXPECT_TRUE(output.lost);
+    EXPECT_LT(output.confidence, 0.22);
+    EXPECT_NE(output.source, "tdoa-recovery");
+    EXPECT_NE(output.source, "vio-tdoa-fused");
+}
+
+TEST(LocalizationFusion, InvalidTdoaConfidenceCannotRaiseConfidence) {
+    localization::LocalizationFusion fusion;
+    localization::LocalizationFusionInput input;
+    input.vio_pose.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+    input.vio_pose.drift_m = 2.0;
+    input.vio_pose.localization_confidence = 0.20;
+    input.camera_available = false;
+    input.anchor_visibility_ratio = 1.0;
+    input.time_sync.confidence = 1.0;
+    input.time_sync.synchronized = true;
+
+    localization::TDOALocalizer::Solution tdoa_solution;
+    tdoa_solution.position = Eigen::Vector3d(2.0, 0.0, 3.0);
+    tdoa_solution.confidence = std::numeric_limits<double>::infinity();
+    input.tdoa_solution = tdoa_solution;
+
+    const auto output = fusion.update(input);
+    EXPECT_DOUBLE_EQ(output.tdoa_weight, 0.0);
+    EXPECT_TRUE(output.fused_position.isApprox(input.vio_pose.position));
+    EXPECT_TRUE(output.lost);
+    EXPECT_LT(output.confidence, 0.22);
+    EXPECT_NE(output.source, "tdoa-recovery");
+    EXPECT_NE(output.source, "vio-tdoa-fused");
 }
 
 TEST(LocalizationFusion, MarksLocalizationLostWhenCameraAndSyncCollapse) {


### PR DESCRIPTION
## Summary

`LocalizationFusion` rejects non-finite TDOA values during weighted fusion, but the later confidence-floor and recovery-source paths only checked whether a TDOA solution existed. A solution already classified as invalid could therefore still influence localization state.

A concrete failure case on current `main`: weak VIO confidence (`0.20`) plus a TDOA solution with a `NaN` position, confidence `1.0`, good time sync, and full anchor visibility skips weighted fusion but still produces a TDOA confidence floor of `1.0`. That can turn a state that should remain `lost` into a high-confidence state.

This change carries the same validity decision through every TDOA-derived path:

- invalid TDOA cannot contribute to the confidence floor
- invalid TDOA cannot claim `tdoa-recovery` or `vio-tdoa-fused`
- the existing valid-TDOA weighting path is unchanged
- the confidence floor reuses the same clamped TDOA confidence as weighted fusion

## Regression coverage

Adds focused cases for non-finite TDOA position and non-finite TDOA confidence. Both verify that invalid TDOA leaves the VIO position untouched, contributes zero TDOA weight, does not raise confidence above the lost threshold, and does not claim a TDOA-derived source. The existing valid-TDOA test continues to cover the normal fusion path.

## Validation

- one focused commit, two files
- branch is based on current `main` (`a223bb2`)
- regression coverage is in the existing `test_navigation_intelligence` target
- repository workflows are awaiting maintainer approval for this fork PR

No flight, HIL, radio, or hardware-validation claims are changed.