### PR TITLE
Continue CI repair after linker fix

### DIFF
--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -37,3 +37,33 @@ jobs:
           path: ${{ runner.temp }}/ci-diagnostic/gcc-release-build.log
           if-no-files-found: error
           retention-days: 3
+
+  formatting-diagnostic:
+    name: Formatting Diagnostic
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install clang-format 15
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-15
+
+      - name: Capture formatting violations
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
+          mapfile -t files < <(find include src tests apps -type f \( -name '*.h' -o -name '*.hpp' -o -name '*.c' -o -name '*.cc' -o -name '*.cpp' \) -print | sort)
+          clang-format-15 --dry-run --Werror "${files[@]}" 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log"
+
+      - name: Upload formatting diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: clang-format-${{ github.sha }}
+          path: ${{ runner.temp }}/ci-diagnostic/clang-format.log
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -45,19 +45,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install clang-format 15
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install CI clang-format
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format-15
+          python3 -m pip install --upgrade pip
+          python3 -m pip install clang-format==19.1.7
 
       - name: Capture formatting violations
         shell: bash
         run: |
           set -o pipefail
           mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
-          mapfile -t files < <(find include src tests apps -type f \( -name '*.h' -o -name '*.hpp' -o -name '*.c' -o -name '*.cc' -o -name '*.cpp' \) -print | sort)
-          clang-format-15 --dry-run --Werror "${files[@]}" 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log"
+          python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log"
 
       - name: Upload formatting diagnostic log
         if: always()

--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -13,6 +13,7 @@ add_executable(test_visual_feature_track_manager
 target_link_libraries(test_visual_feature_track_manager PRIVATE
     drone_test_support
     Eigen3::Eigen
+    spdlog::spdlog
 )
 drone_apply_project_warnings(test_visual_feature_track_manager)
 drone_enable_coverage(test_visual_feature_track_manager)


### PR DESCRIPTION
Continuation of CI repair on fix/ci-resolve. Adds the missing spdlog/fmt linkage for test_visual_feature_track_manager. Keep draft until the full CI/security matrix is green.