### PR TITLE
Continue CI repair: formatting and remaining failures

### DIFF
--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -58,15 +58,32 @@ jobs:
       - name: Capture formatting violations
         shell: bash
         run: |
-          set -o pipefail
           mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
-          python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log"
+          python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log" || true
 
-      - name: Upload formatting diagnostic log
+      - name: Export exact formatted files
+        shell: bash
+        run: |
+          set -euo pipefail
+          formatted_root="${RUNNER_TEMP}/ci-diagnostic/formatted"
+          mkdir -p "${formatted_root}"
+          mapfile -t files < <(git ls-files '*.h' '*.hpp' '*.c' '*.cc' '*.cpp' | grep -E '^(include|src|tests|apps)/' | sort)
+          clang-format -i "${files[@]}"
+          git diff --name-only -- "${files[@]}" > "${RUNNER_TEMP}/ci-diagnostic/formatted-files.txt"
+          while IFS= read -r file; do
+            [ -n "${file}" ] || continue
+            mkdir -p "${formatted_root}/$(dirname "${file}")"
+            cp "${file}" "${formatted_root}/${file}"
+          done < "${RUNNER_TEMP}/ci-diagnostic/formatted-files.txt"
+
+      - name: Upload formatting diagnostic bundle
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: clang-format-${{ github.sha }}
-          path: ${{ runner.temp }}/ci-diagnostic/clang-format.log
+          path: |
+            ${{ runner.temp }}/ci-diagnostic/clang-format.log
+            ${{ runner.temp }}/ci-diagnostic/formatted-files.txt
+            ${{ runner.temp }}/ci-diagnostic/formatted
           if-no-files-found: error
           retention-days: 3


### PR DESCRIPTION
Continue CI repair on fix/ci-resolve after PR #30 was merged. This draft exists only to run verification and export exact clang-format fixes. Do not merge until the full CI/security matrix is green.