### PR TITLE
Verify final CI repairs

### DIFF
--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -1,6 +1,9 @@
 name: CI Diagnostic
 
 on:
+  push:
+    branches:
+      - fix/ci-resolve
   pull_request:
     branches:
       - main
@@ -45,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v7
         with:
@@ -93,24 +96,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t files < <(git ls-files '*.h' '*.hpp' '*.c' '*.cc' '*.cpp' | grep -E '^(include|src|tests|apps)/' | sort)
+          mapfile -t files < <(git ls-files '*.h' '*.hpp' '*.c' '*.cc' '*.cpp' | grep -E '^(include|src|tests)/' | sort)
           clang-format -i "${files[@]}"
           git diff --name-only -- "${files[@]}" > "${RUNNER_TEMP}/ci-diagnostic/formatted-files.txt"
 
       - name: Commit source repairs to fix branch
-        if: github.event_name == 'pull_request' && github.head_ref == 'fix/ci-resolve' && github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve') || (github.event_name == 'pull_request' && github.head_ref == 'fix/ci-resolve' && github.event.pull_request.head.repo.full_name == github.repository)
         shell: bash
         run: |
           set -euo pipefail
-          if git diff --quiet -- include src tests apps; then
+          if git diff --quiet -- include src tests; then
             echo "No source repairs required."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -- include src tests apps
+          git add -- include src tests
           git commit -m "Fix CI formatting and MSVC retirement iterator"
-          git push origin "HEAD:refs/heads/${{ github.head_ref }}"
+          git push origin "HEAD:refs/heads/fix/ci-resolve"
 
       - name: Verify formatting after repair
         shell: bash

--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -71,6 +71,36 @@ jobs:
           if-no-files-found: warn
           retention-days: 3
 
+  static-analysis-diagnostic:
+    name: Static Analysis Diagnostic
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-linux-deps
+
+      - name: Configure compile commands
+        shell: bash
+        run: cmake --preset linux-gcc-release-minimal
+
+      - name: Run clang-tidy with captured output
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
+          python3 scripts/run_clang_tidy.py --build-dir build/linux-gcc-release-minimal --changed-only 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-tidy.log"
+
+      - name: Upload clang-tidy diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: clang-tidy-${{ github.sha }}
+          path: ${{ runner.temp }}/ci-diagnostic/clang-tidy.log
+          if-no-files-found: error
+          retention-days: 3
+
   windows-msvc-debug-diagnostic:
     name: Windows MSVC Retirement Diagnostic
     needs: formatting-diagnostic

--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -1,16 +1,13 @@
 name: CI Diagnostic
 
 on:
-  push:
-    branches:
-      - fix/ci-resolve
   pull_request:
     branches:
       - main
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   gcc-release-diagnostic:
@@ -58,75 +55,19 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install clang-format==19.1.7
 
-      - name: Apply known source repairs
-        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
-        shell: bash
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path("src/vio/Phase17ESKFEstimator.cpp")
-          text = path.read_text(encoding="utf-8")
-
-          anchor = """    const auto state_it = msckf_camera_states_.find(oldest_id);\n    if (state_it == msckf_camera_states_.end()) {\n        if (msckf_diagnostics_enabled_locked()) {\n            ++diagnostics_.marginalization_failures;\n        }\n        note_rejection_locked(EstimatorOperationResult::FailedNumericalValidation);\n        refresh_msckf_oldest_state_age_locked();\n        return;\n    }\n\n"""
-          replacement = anchor + "    const int64_t retiring_timestamp_key = state_it->second.timestamp_key;\n\n"
-          if "const int64_t retiring_timestamp_key = state_it->second.timestamp_key;" not in text:
-              if anchor not in text:
-                  raise SystemExit("retirement iterator anchor not found")
-              text = text.replace(anchor, replacement, 1)
-
-          stale = "candidate_timestamp_map.erase(state_it->second.timestamp_key);"
-          safe = "candidate_timestamp_map.erase(retiring_timestamp_key);"
-          if stale in text:
-              text = text.replace(stale, safe, 1)
-          elif safe not in text:
-              raise SystemExit("retirement timestamp erase anchor not found")
-
-          path.write_text(text, encoding="utf-8")
-          PY
-
-      - name: Capture formatting violations
+      - name: Verify formatting
         shell: bash
         run: |
           mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
-          python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log" || true
+          set -o pipefail
+          python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log"
 
-      - name: Apply exact CI formatting
-        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(git ls-files '*.h' '*.hpp' '*.c' '*.cc' '*.cpp' | grep -E '^(include|src|tests)/' | sort)
-          clang-format -i "${files[@]}"
-          git diff --name-only -- "${files[@]}" > "${RUNNER_TEMP}/ci-diagnostic/formatted-files.txt"
-
-      - name: Commit source repairs to fix branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- include src tests; then
-            echo "No source repairs required."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -- include src tests
-          git commit -m "Fix CI formatting and MSVC retirement iterator"
-          git push origin HEAD:refs/heads/fix/ci-resolve
-
-      - name: Verify formatting after repair
-        shell: bash
-        run: python3 scripts/check_clang_format.py
-
-      - name: Upload formatting diagnostic bundle
+      - name: Upload formatting diagnostic log
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: clang-format-${{ github.sha }}
-          path: |
-            ${{ runner.temp }}/ci-diagnostic/clang-format.log
-            ${{ runner.temp }}/ci-diagnostic/formatted-files.txt
+          path: ${{ runner.temp }}/ci-diagnostic/clang-format.log
           if-no-files-found: warn
           retention-days: 3
 
@@ -137,9 +78,6 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: fix/ci-resolve
-
       - uses: ./.github/actions/setup-vcpkg
         with:
           cache-key-suffix: retirement-diagnostic
@@ -152,6 +90,6 @@ jobs:
         shell: pwsh
         run: cmake --build --preset windows-msvc-debug --target test_msckf_marginalization_integration --parallel
 
-      - name: Run failing retirement regression
+      - name: Run retirement regression
         shell: pwsh
         run: ctest --preset windows-msvc-debug -R "^MsckfMarginalizationIntegration.RetirementConsumesEligibleConstraintBeforeCloneRemoval$" --output-on-failure

--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -47,8 +47,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-python@v7
         with:
@@ -61,6 +59,7 @@ jobs:
           python3 -m pip install clang-format==19.1.7
 
       - name: Apply known source repairs
+        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
         shell: bash
         run: |
           python3 - <<'PY'
@@ -93,6 +92,7 @@ jobs:
           python3 scripts/check_clang_format.py 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/clang-format.log" || true
 
       - name: Apply exact CI formatting
+        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
         shell: bash
         run: |
           set -euo pipefail
@@ -101,7 +101,7 @@ jobs:
           git diff --name-only -- "${files[@]}" > "${RUNNER_TEMP}/ci-diagnostic/formatted-files.txt"
 
       - name: Commit source repairs to fix branch
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve') || (github.event_name == 'pull_request' && github.head_ref == 'fix/ci-resolve' && github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/fix/ci-resolve'
         shell: bash
         run: |
           set -euo pipefail
@@ -113,7 +113,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- include src tests
           git commit -m "Fix CI formatting and MSVC retirement iterator"
-          git push origin "HEAD:refs/heads/fix/ci-resolve"
+          git push origin HEAD:refs/heads/fix/ci-resolve
 
       - name: Verify formatting after repair
         shell: bash

--- a/include/vio/EstimatorPromotionSoakMonitor.hpp
+++ b/include/vio/EstimatorPromotionSoakMonitor.hpp
@@ -47,20 +47,27 @@ public:
 
         const bool blocked_limit_ok =
             state_.consecutive_blocked_samples <= cfg_.maximum_consecutive_blocked_samples;
-        state_.sustained_ready = blocked_limit_ok &&
-            state_.consecutive_ready_samples >= cfg_.minimum_ready_samples;
+        state_.sustained_ready =
+            blocked_limit_ok && state_.consecutive_ready_samples >= cfg_.minimum_ready_samples;
         return state_;
     }
 
-    [[nodiscard]] const PromotionSoakState& observe(const CoordinatorDiagnostics& diagnostics,
-                                                    const PromotionReadinessConfig& readiness_cfg = {}) {
+    [[nodiscard]] const PromotionSoakState&
+    observe(const CoordinatorDiagnostics& diagnostics,
+            const PromotionReadinessConfig& readiness_cfg = {}) {
         return observe(assess_promotion_readiness(diagnostics, readiness_cfg));
     }
 
-    void reset() { state_ = {}; }
+    void reset() {
+        state_ = {};
+    }
 
-    [[nodiscard]] const PromotionSoakState& state() const { return state_; }
-    [[nodiscard]] const PromotionSoakConfig& config() const { return cfg_; }
+    [[nodiscard]] const PromotionSoakState& state() const {
+        return state_;
+    }
+    [[nodiscard]] const PromotionSoakConfig& config() const {
+        return cfg_;
+    }
 
 private:
     PromotionSoakConfig cfg_{};

--- a/include/vio/MsckfMarginalization.hpp
+++ b/include/vio/MsckfMarginalization.hpp
@@ -36,8 +36,7 @@ struct MarginalizationCovarianceHealth {
 class MsckfMarginalization final {
 public:
     [[nodiscard]] static MarginalizationPlan
-    build_plan(uint64_t retiring_state_id,
-               const std::vector<MarginalizationTrackSummary>& tracks,
+    build_plan(uint64_t retiring_state_id, const std::vector<MarginalizationTrackSummary>& tracks,
                uint32_t minimum_track_length) {
         MarginalizationPlan plan;
         plan.retiring_state_id = retiring_state_id;
@@ -47,17 +46,16 @@ public:
         for (const auto& track : tracks) {
             ordered.push_back(&track);
         }
-        std::sort(ordered.begin(), ordered.end(), [](const auto* lhs, const auto* rhs) {
-            return lhs->track_id < rhs->track_id;
-        });
+        std::sort(ordered.begin(), ordered.end(),
+                  [](const auto* lhs, const auto* rhs) { return lhs->track_id < rhs->track_id; });
 
         for (const auto* track : ordered) {
             if (track == nullptr || track->track_id == 0u) {
                 continue;
             }
-            const auto retiring_refs = static_cast<uint64_t>(std::count(
-                track->observation_state_ids.begin(), track->observation_state_ids.end(),
-                retiring_state_id));
+            const auto retiring_refs = static_cast<uint64_t>(
+                std::count(track->observation_state_ids.begin(), track->observation_state_ids.end(),
+                           retiring_state_id));
             if (retiring_refs == 0u) {
                 continue;
             }
@@ -87,8 +85,7 @@ public:
 
     [[nodiscard]] static std::optional<Eigen::MatrixXd>
     retained_principal_submatrix(const Eigen::MatrixXd& augmented_covariance,
-                                 std::size_t base_error_dim,
-                                 std::size_t clone_error_dim,
+                                 std::size_t base_error_dim, std::size_t clone_error_dim,
                                  const std::vector<uint64_t>& ordered_clone_ids,
                                  uint64_t retiring_state_id) {
         if (base_error_dim == 0u || clone_error_dim == 0u || retiring_state_id == 0u ||
@@ -111,8 +108,7 @@ public:
         const std::size_t remove_begin = base_error_dim + (clone_index * clone_error_dim);
         const std::size_t remove_end = remove_begin + clone_error_dim;
 
-        const Eigen::Index retained_dim =
-            static_cast<Eigen::Index>(expected_dim - clone_error_dim);
+        const Eigen::Index retained_dim = static_cast<Eigen::Index>(expected_dim - clone_error_dim);
         Eigen::MatrixXd retained = Eigen::MatrixXd::Zero(retained_dim, retained_dim);
 
         std::vector<Eigen::Index> retained_indices;
@@ -154,9 +150,8 @@ public:
             return health;
         }
         health.minimum_eigenvalue = solver.eigenvalues().minCoeff();
-        health.psd_within_tolerance =
-            std::isfinite(health.minimum_eigenvalue) &&
-            health.minimum_eigenvalue >= -negativity_tolerance;
+        health.psd_within_tolerance = std::isfinite(health.minimum_eigenvalue) &&
+                                      health.minimum_eigenvalue >= -negativity_tolerance;
         return health;
     }
 };

--- a/include/vio/MsckfRetirementTransaction.hpp
+++ b/include/vio/MsckfRetirementTransaction.hpp
@@ -35,8 +35,7 @@ struct MsckfRetirementResult {
 class MsckfRetirementTransaction final {
 public:
     [[nodiscard]] static std::optional<MsckfRetirementResult>
-    prepare(const MsckfRetirementRequest& request,
-            const std::vector<uint64_t>& ordered_clone_ids,
+    prepare(const MsckfRetirementRequest& request, const std::vector<uint64_t>& ordered_clone_ids,
             const Eigen::MatrixXd& post_constraint_augmented_covariance) {
         if (request.retiring_state_id == 0u || request.base_error_dim == 0u ||
             request.clone_error_dim == 0u || request.symmetry_tolerance < 0.0 ||
@@ -52,8 +51,8 @@ public:
         }
 
         const auto retained = MsckfMarginalization::retained_principal_submatrix(
-            post_constraint_augmented_covariance, request.base_error_dim,
-            request.clone_error_dim, ordered_clone_ids, request.retiring_state_id);
+            post_constraint_augmented_covariance, request.base_error_dim, request.clone_error_dim,
+            ordered_clone_ids, request.retiring_state_id);
         if (!retained.has_value()) {
             return std::nullopt;
         }

--- a/include/vio/VIOPipeline.hpp
+++ b/include/vio/VIOPipeline.hpp
@@ -142,7 +142,9 @@ public:
     using PoseCallback = std::function<void(const PoseEstimate&)>;
 
     explicit VIOPipeline(EKFConfig cfg = EKFConfig{});
-    ~VIOPipeline() { stop(); }
+    ~VIOPipeline() {
+        stop();
+    }
 
     void attach_imu(std::shared_ptr<sensors::IMUSensor> imu);
     void attach_camera(std::shared_ptr<sensors::CameraSensor> cam);
@@ -151,7 +153,9 @@ public:
     bool start();
     void stop();
     void reset();
-    void set_runtime_mode(drone::runtime::RuntimeMode mode) { runtime_mode_ = mode; }
+    void set_runtime_mode(drone::runtime::RuntimeMode mode) {
+        runtime_mode_ = mode;
+    }
     void set_estimator_validation_config(const EstimatorValidationConfig& cfg);
     void set_shadow_msckf_config(const MsckfConfig& cfg);
 
@@ -162,8 +166,12 @@ public:
         return runtime_telemetry_;
     }
 
-    void set_pose_callback(PoseCallback cb) { pose_cb_ = std::move(cb); }
-    void set_camera_matrix(const Eigen::Matrix3d& K) { K_ = K; }
+    void set_pose_callback(PoseCallback cb) {
+        pose_cb_ = std::move(cb);
+    }
+    void set_camera_matrix(const Eigen::Matrix3d& K) {
+        K_ = K;
+    }
     void set_runtime_telemetry(RuntimeTelemetry telemetry) {
         std::lock_guard lock(runtime_mutex_);
         telemetry.tracked_feature_count = runtime_telemetry_.tracked_feature_count;

--- a/include/vio/VisualFeatureTrackManager.hpp
+++ b/include/vio/VisualFeatureTrackManager.hpp
@@ -59,12 +59,10 @@ public:
         return next_track_id_;
     }
 
-    [[nodiscard]] VisualFeatureTrackBatch update(
-        const std::vector<Eigen::Vector2d>& previous_pixels,
-        const std::vector<Eigen::Vector2d>& current_pixels,
-        const PoseEstimate& previous_pose,
-        const PoseEstimate& current_pose,
-        const Eigen::Matrix3d& K) {
+    [[nodiscard]] VisualFeatureTrackBatch
+    update(const std::vector<Eigen::Vector2d>& previous_pixels,
+           const std::vector<Eigen::Vector2d>& current_pixels, const PoseEstimate& previous_pose,
+           const PoseEstimate& current_pose, const Eigen::Matrix3d& K) {
         VisualFeatureTrackBatch batch;
         if (!inputs_valid(previous_pixels, current_pixels, previous_pose, current_pose, K)) {
             tracks_.clear();
@@ -148,8 +146,8 @@ private:
         }
         if (config_.association_radius_px <= 0.0 || config_.minimum_baseline_m < 0.0 ||
             config_.minimum_parallax_deg < 0.0 || config_.maximum_ray_gap_m <= 0.0 ||
-            config_.minimum_depth_m <= 0.0 ||
-            config_.maximum_depth_m <= config_.minimum_depth_m || config_.maximum_tracks == 0) {
+            config_.minimum_depth_m <= 0.0 || config_.maximum_depth_m <= config_.minimum_depth_m ||
+            config_.maximum_tracks == 0) {
             return false;
         }
         return previous_pose.position.array().isFinite().all() &&
@@ -162,7 +160,8 @@ private:
     [[nodiscard]] std::optional<uint64_t>
     match_track(const Eigen::Vector2d& previous_pixel, const std::vector<uint64_t>& ordered_ids,
                 const std::unordered_set<uint64_t>& claimed) const {
-        const double max_distance_sq = config_.association_radius_px * config_.association_radius_px;
+        const double max_distance_sq =
+            config_.association_radius_px * config_.association_radius_px;
         double best_distance_sq = max_distance_sq;
         std::optional<uint64_t> best_id;
         for (const uint64_t id : ordered_ids) {

--- a/src/localization/LocalizationFusion.cpp
+++ b/src/localization/LocalizationFusion.cpp
@@ -52,8 +52,7 @@ LocalizationFusionOutput LocalizationFusion::update(const LocalizationFusionInpu
         confidence *= std::clamp(input.time_sync.confidence, 0.35, 1.0);
     }
     confidence *= std::clamp(0.65 + input.anchor_visibility_ratio * 0.35, 0.65, 1.0);
-    if (tdoa_valid && input.time_sync.confidence >= 0.8 &&
-        input.anchor_visibility_ratio >= 0.5) {
+    if (tdoa_valid && input.time_sync.confidence >= 0.8 && input.anchor_visibility_ratio >= 0.5) {
         const double tdoa_floor = (tdoa_conf * 0.55) +
                                   (std::clamp(input.anchor_visibility_ratio, 0.0, 1.0) * 0.25) +
                                   (std::clamp(input.time_sync.confidence, 0.0, 1.0) * 0.20);

--- a/src/vio/Phase17ESKFEstimator.cpp
+++ b/src/vio/Phase17ESKFEstimator.cpp
@@ -1370,6 +1370,8 @@ void Phase17ESKFEstimator::evict_msckf_state_locked() {
         return;
     }
 
+    const int64_t retiring_timestamp_key = state_it->second.timestamp_key;
+
     std::vector<MarginalizationTrackSummary> summaries;
     summaries.reserve(feature_tracks_.size());
     for (const auto& [key, track] : feature_tracks_) {
@@ -1383,10 +1385,10 @@ void Phase17ESKFEstimator::evict_msckf_state_locked() {
         }
         summaries.push_back(std::move(summary));
     }
-    const auto plan = MsckfMarginalization::build_plan(
-        oldest_id, summaries, msckf_cfg_.update.minimum_track_length);
+    const auto plan = MsckfMarginalization::build_plan(oldest_id, summaries,
+                                                       msckf_cfg_.update.minimum_track_length);
     const std::vector<uint64_t> ordered_clone_ids(msckf_state_order_.begin(),
-                                                   msckf_state_order_.end());
+                                                  msckf_state_order_.end());
 
     MsckfRetirementRequest request;
     request.retiring_state_id = oldest_id;
@@ -1449,8 +1451,8 @@ void Phase17ESKFEstimator::evict_msckf_state_locked() {
         }
     }
 
-    const auto prepared = MsckfRetirementTransaction::prepare(
-        request, ordered_clone_ids, augmented_covariance_);
+    const auto prepared =
+        MsckfRetirementTransaction::prepare(request, ordered_clone_ids, augmented_covariance_);
     if (!prepared.has_value() || !prepared->committed) {
         restore_pre_retirement();
         if (msckf_diagnostics_enabled_locked()) {
@@ -1467,7 +1469,7 @@ void Phase17ESKFEstimator::evict_msckf_state_locked() {
     auto candidate_timestamp_map = msckf_timestamp_to_state_id_;
     auto candidate_tracks = feature_tracks_;
     candidate_order.pop_front();
-    candidate_timestamp_map.erase(state_it->second.timestamp_key);
+    candidate_timestamp_map.erase(retiring_timestamp_key);
     candidate_states.erase(oldest_id);
     for (auto track_it = candidate_tracks.begin(); track_it != candidate_tracks.end();) {
         auto& observations = track_it->second.observations;
@@ -1486,16 +1488,17 @@ void Phase17ESKFEstimator::evict_msckf_state_locked() {
     uint64_t stale_references = 0;
     for (const auto& [key, track] : candidate_tracks) {
         (void)key;
-        stale_references += static_cast<uint64_t>(std::count_if(
-            track.observations.begin(), track.observations.end(),
-            [oldest_id](const FeatureObservation& observation) {
-                return observation.state_id == oldest_id;
-            }));
+        stale_references += static_cast<uint64_t>(
+            std::count_if(track.observations.begin(), track.observations.end(),
+                          [oldest_id](const FeatureObservation& observation) {
+                              return observation.state_id == oldest_id;
+                          }));
     }
     const auto health = MsckfMarginalization::covariance_health(
         prepared->retained_covariance, validation_cfg_.covariance_symmetry_tolerance,
         validation_cfg_.variance_negativity_tolerance);
-    const std::size_t expected_dim = static_cast<std::size_t>(kErrorDim) +
+    const std::size_t expected_dim =
+        static_cast<std::size_t>(kErrorDim) +
         candidate_order.size() * static_cast<std::size_t>(AugmentedStateLayout::kCloneErrorDim);
     const bool candidate_valid =
         health.finite && health.symmetric && health.psd_within_tolerance &&
@@ -2832,10 +2835,8 @@ EstimatorStateSnapshot Phase17StateEstimatorAdapter::snapshot() const {
     out.marginalization_covariance_dim_before = diag.marginalization_covariance_dim_before;
     out.marginalization_covariance_dim_after = diag.marginalization_covariance_dim_after;
     out.marginalization_stale_references = diag.marginalization_stale_references;
-    out.marginalization_covariance_symmetry_error =
-        diag.marginalization_covariance_symmetry_error;
-    out.marginalization_covariance_min_eigenvalue =
-        diag.marginalization_covariance_min_eigenvalue;
+    out.marginalization_covariance_symmetry_error = diag.marginalization_covariance_symmetry_error;
+    out.marginalization_covariance_min_eigenvalue = diag.marginalization_covariance_min_eigenvalue;
     out.triangulation_attempts = diag.triangulation_attempts;
     out.triangulation_successes = diag.triangulation_successes;
     out.triangulation_failures = diag.triangulation_failures;

--- a/src/vio/VIOPipeline.cpp
+++ b/src/vio/VIOPipeline.cpp
@@ -37,13 +37,16 @@ bool thread_sanitizer_enabled() {
 
 void configure_opencv_threads_for_tsan() {
     static std::once_flag once;
-    if (!thread_sanitizer_enabled()) return;
+    if (!thread_sanitizer_enabled())
+        return;
     std::call_once(once, [] { cv::setNumThreads(1); });
 }
 
 cv::Mat to_gray(const cv::Mat& image) {
-    if (image.empty()) return {};
-    if (image.channels() == 1) return image.clone();
+    if (image.empty())
+        return {};
+    if (image.channels() == 1)
+        return image.clone();
     cv::Mat gray;
     cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
     return gray;
@@ -53,7 +56,8 @@ double mean_optical_flow_error(const std::vector<float>& errors, const std::vect
     double sum = 0.0;
     size_t count = 0;
     for (size_t i = 0; i < errors.size() && i < status.size(); ++i) {
-        if (!status[i]) continue;
+        if (!status[i])
+            continue;
         sum += static_cast<double>(errors[i]);
         ++count;
     }
@@ -65,7 +69,8 @@ VIOPipeline::VIOPipeline(EKFConfig cfg) : ekf_cfg_(cfg) {
     ShadowCoordinatorConfig shadow_cfg{};
     coordinator_ = std::make_unique<EstimatorCoordinator>(
         std::make_unique<EKFStateEstimatorAdapter>(ekf_cfg_, "ekf_active", "phase16"),
-        std::make_unique<Phase17StateEstimatorAdapter>(ekf_cfg_, "eskf_shadow", "phase17"), shadow_cfg);
+        std::make_unique<Phase17StateEstimatorAdapter>(ekf_cfg_, "eskf_shadow", "phase17"),
+        shadow_cfg);
 }
 
 bool visual_placeholder_allowed(drone::runtime::RuntimeMode mode) {
@@ -73,14 +78,17 @@ bool visual_placeholder_allowed(drone::runtime::RuntimeMode mode) {
 }
 
 double compute_visual_update_confidence(const VisualFrontendMetrics& metrics) {
-    if (metrics.tracked_feature_count == 0) return kDefaultVisualConfidenceOnFailure;
+    if (metrics.tracked_feature_count == 0)
+        return kDefaultVisualConfidenceOnFailure;
     const double feature_score =
         std::clamp(static_cast<double>(metrics.tracked_feature_count) / 140.0, 0.0, 1.0);
     const double inlier_score = std::clamp(metrics.inlier_ratio, 0.0, 1.0);
     const double reprojection_score = std::clamp(1.0 - metrics.reprojection_error / 8.0, 0.0, 1.0);
     double confidence = feature_score * 0.35 + inlier_score * 0.45 + reprojection_score * 0.20;
-    if (!metrics.update_accepted) confidence *= 0.45;
-    if (metrics.used_placeholder) confidence = std::min(confidence, kDefaultVisualConfidenceOnPlaceholder);
+    if (!metrics.update_accepted)
+        confidence *= 0.45;
+    if (metrics.used_placeholder)
+        confidence = std::min(confidence, kDefaultVisualConfidenceOnPlaceholder);
     return std::clamp(confidence, 0.0, 1.0);
 }
 
@@ -96,7 +104,8 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
     }
 
     std::vector<cv::Point2f> previous_points;
-    cv::goodFeaturesToTrack(previous_gray, previous_points, static_cast<int>(kMaxFeatures), 0.01, 8.0);
+    cv::goodFeaturesToTrack(previous_gray, previous_points, static_cast<int>(kMaxFeatures), 0.01,
+                            8.0);
     if (previous_points.size() < 8) {
         result.metrics.tracked_feature_count = previous_points.size();
         result.metrics.visual_update_confidence = kDefaultVisualConfidenceOnFailure;
@@ -114,7 +123,8 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
     tracked_prev.reserve(previous_points.size());
     tracked_curr.reserve(previous_points.size());
     for (size_t i = 0; i < previous_points.size() && i < status.size(); ++i) {
-        if (!status[i]) continue;
+        if (!status[i])
+            continue;
         tracked_prev.push_back(previous_points[i]);
         tracked_curr.push_back(current_points[i]);
     }
@@ -127,12 +137,13 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     cv::Mat K_cv(3, 3, CV_64F);
     for (int r = 0; r < 3; ++r) {
-        for (int c = 0; c < 3; ++c) K_cv.at<double>(r, c) = K(r, c);
+        for (int c = 0; c < 3; ++c)
+            K_cv.at<double>(r, c) = K(r, c);
     }
 
     cv::Mat inlier_mask;
-    const cv::Mat essential = cv::findEssentialMat(tracked_prev, tracked_curr, K_cv, cv::RANSAC,
-                                                    0.999, 1.5, inlier_mask);
+    const cv::Mat essential =
+        cv::findEssentialMat(tracked_prev, tracked_curr, K_cv, cv::RANSAC, 0.999, 1.5, inlier_mask);
     if (essential.empty() || inlier_mask.empty()) {
         result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
         return result;
@@ -140,18 +151,19 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     int inlier_count = 0;
     for (int i = 0; i < inlier_mask.rows; ++i) {
-        if (inlier_mask.at<uchar>(i, 0) != 0) ++inlier_count;
+        if (inlier_mask.at<uchar>(i, 0) != 0)
+            ++inlier_count;
     }
-    result.metrics.inlier_ratio = tracked_curr.empty()
-                                      ? 0.0
-                                      : static_cast<double>(inlier_count) /
-                                            static_cast<double>(tracked_curr.size());
+    result.metrics.inlier_ratio =
+        tracked_curr.empty()
+            ? 0.0
+            : static_cast<double>(inlier_count) / static_cast<double>(tracked_curr.size());
 
     cv::Mat R_cv;
     cv::Mat t_cv;
     cv::Mat recover_mask;
-    const int recovered = cv::recoverPose(essential, tracked_prev, tracked_curr, K_cv, R_cv, t_cv,
-                                          recover_mask);
+    const int recovered =
+        cv::recoverPose(essential, tracked_prev, tracked_curr, K_cv, R_cv, t_cv, recover_mask);
     if (recovered < static_cast<int>(kMinTrackedFeatures / 2)) {
         result.metrics.visual_update_confidence = compute_visual_update_confidence(result.metrics);
         return result;
@@ -164,12 +176,14 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
                                       inlier_mask.at<uchar>(static_cast<int>(i), 0) != 0;
         const bool pose_inlier = i < static_cast<size_t>(recover_mask.rows) &&
                                  recover_mask.at<uchar>(static_cast<int>(i), 0) != 0;
-        if (!essential_inlier || !pose_inlier) continue;
+        if (!essential_inlier || !pose_inlier)
+            continue;
         result.previous_inlier_pixels.emplace_back(tracked_prev[i].x, tracked_prev[i].y);
         result.current_inlier_pixels.emplace_back(tracked_curr[i].x, tracked_curr[i].y);
     }
 
-    const Eigen::Vector3d predicted_delta = current_predicted_pose.position - previous_pose.position;
+    const Eigen::Vector3d predicted_delta =
+        current_predicted_pose.position - previous_pose.position;
     const double predicted_scale =
         std::max(predicted_delta.norm(), current_predicted_pose.velocity.norm() * dt_s);
     if (predicted_scale < 1.0e-4) {
@@ -179,7 +193,8 @@ VisualFrontendResult run_visual_frontend(const cv::Mat& previous_gray, const cv:
 
     Eigen::Matrix3d relative_rotation = Eigen::Matrix3d::Identity();
     for (int r = 0; r < 3; ++r) {
-        for (int c = 0; c < 3; ++c) relative_rotation(r, c) = R_cv.at<double>(r, c);
+        for (int c = 0; c < 3; ++c)
+            relative_rotation(r, c) = R_cv.at<double>(r, c);
     }
     Eigen::Vector3d translation_direction{t_cv.at<double>(0, 0), t_cv.at<double>(1, 0),
                                           t_cv.at<double>(2, 0)};
@@ -207,7 +222,8 @@ VisualFrontendResult build_placeholder_visual_frontend_result(const sensors::Cam
     result.metrics.used_placeholder = true;
     size_t accepted = 0;
     for (const auto& det : frame.detections) {
-        if (det.confidence >= 0.6f) ++accepted;
+        if (det.confidence >= 0.6f)
+            ++accepted;
     }
     result.metrics.tracked_feature_count = accepted;
     result.metrics.inlier_ratio = accepted == 0 ? 0.0 : 1.0;
@@ -236,28 +252,36 @@ void VIOPipeline::attach_lidar(std::shared_ptr<sensors::LidarSensor> lidar) {
 }
 
 bool VIOPipeline::start() {
-    if (running_.exchange(true)) return true;
+    if (running_.exchange(true))
+        return true;
     if (coordinator_) {
         coordinator_->initialize();
         (void)coordinator_->start();
     }
     proc_thread_ = std::thread([this] { processing_loop(); });
-    if (logger_) logger_->info("VIO pipeline started");
+    if (logger_)
+        logger_->info("VIO pipeline started");
     return true;
 }
 
 void VIOPipeline::stop() {
-    if (!running_.exchange(false)) return;
+    if (!running_.exchange(false))
+        return;
     queue_cv_.notify_all();
-    if (proc_thread_.joinable()) proc_thread_.join();
-    if (coordinator_) coordinator_->stop();
-    if (logger_) logger_->info("VIO pipeline stopped");
+    if (proc_thread_.joinable())
+        proc_thread_.join();
+    if (coordinator_)
+        coordinator_->stop();
+    if (logger_)
+        logger_->info("VIO pipeline stopped");
 }
 
 void VIOPipeline::reset() {
     std::lock_guard lock(queue_mutex_);
-    while (!event_queue_.empty()) event_queue_.pop();
-    if (coordinator_) coordinator_->reset();
+    while (!event_queue_.empty())
+        event_queue_.pop();
+    if (coordinator_)
+        coordinator_->reset();
     last_imu_ts_ = -1.0;
     last_camera_ts_ = -1.0;
     measurement_sequence_ = 0;
@@ -290,7 +314,8 @@ PoseEstimate VIOPipeline::current_pose() const {
 void VIOPipeline::enqueue(SensorEvent evt) {
     {
         std::lock_guard lock(queue_mutex_);
-        if (event_queue_.size() > 2000) event_queue_.pop();
+        if (event_queue_.size() > 2000)
+            event_queue_.pop();
         event_queue_.push(std::move(evt));
     }
     queue_cv_.notify_one();
@@ -302,27 +327,31 @@ void VIOPipeline::processing_loop() {
         {
             std::unique_lock lock(queue_mutex_);
             queue_cv_.wait(lock, [this] { return !event_queue_.empty() || !running_.load(); });
-            if (!running_.load() && event_queue_.empty()) return;
+            if (!running_.load() && event_queue_.empty())
+                return;
             evt = std::move(event_queue_.front());
             event_queue_.pop();
         }
         std::visit([this](auto&& e) { handle(e); }, evt);
-        if (pose_cb_) pose_cb_(current_pose());
+        if (pose_cb_)
+            pose_cb_(current_pose());
     }
 }
 
 void VIOPipeline::handle(const sensors::ImuMeasurement& imu) {
-    if (!coordinator_) return;
-    if (!coordinator_->active_snapshot().initialized) coordinator_->initialize();
+    if (!coordinator_)
+        return;
+    if (!coordinator_->active_snapshot().initialized)
+        coordinator_->initialize();
     last_imu_ts_ = imu.timestamp;
     (void)coordinator_->process_measurement(make_imu_envelope(imu, measurement_sequence_++));
     refresh_runtime_telemetry_from_coordinator();
 }
 
 void VIOPipeline::submit_tracked_features_to_shadow(const VisualFrontendResult& frontend_result,
-                                                     const PoseEstimate& previous_pose,
-                                                     const PoseEstimate& current_pose,
-                                                     double timestamp_s) {
+                                                    const PoseEstimate& previous_pose,
+                                                    const PoseEstimate& current_pose,
+                                                    double timestamp_s) {
     if (!coordinator_ || frontend_result.previous_inlier_pixels.empty() ||
         frontend_result.previous_inlier_pixels.size() !=
             frontend_result.current_inlier_pixels.size()) {
@@ -338,7 +367,8 @@ void VIOPipeline::submit_tracked_features_to_shadow(const VisualFrontendResult& 
         runtime_telemetry_.initialized_feature_tracks += batch.initialized_tracks;
         runtime_telemetry_.rejected_feature_geometry += batch.rejected_geometry;
     }
-    if (batch.features.empty()) return;
+    if (batch.features.empty())
+        return;
 
     VisualFeatureMeasurementPayload payload;
     payload.K = K_;
@@ -358,8 +388,10 @@ void VIOPipeline::submit_tracked_features_to_shadow(const VisualFrontendResult& 
 }
 
 void VIOPipeline::handle(const sensors::CameraFrame& frame) {
-    if (!coordinator_ || !coordinator_->active_snapshot().initialized) return;
-    if (frame.detections.empty() && frame.image.empty()) return;
+    if (!coordinator_ || !coordinator_->active_snapshot().initialized)
+        return;
+    if (frame.detections.empty() && frame.image.empty())
+        return;
 
     const auto predicted_pose = coordinator_->active_pose();
     VisualFrontendResult frontend_result;
@@ -377,10 +409,10 @@ void VIOPipeline::handle(const sensors::CameraFrame& frame) {
         VisualPoseMeasurementPayload payload;
         payload.position_m = frontend_result.observed_position;
         payload.velocity_mps = frontend_result.observed_velocity;
-        payload.sigma_position_m = std::clamp(
-            0.50 - frontend_result.metrics.visual_update_confidence * 0.28, 0.14, 0.50);
-        payload.sigma_velocity_mps = std::clamp(
-            0.65 - frontend_result.metrics.visual_update_confidence * 0.30, 0.18, 0.65);
+        payload.sigma_position_m =
+            std::clamp(0.50 - frontend_result.metrics.visual_update_confidence * 0.28, 0.14, 0.50);
+        payload.sigma_velocity_mps =
+            std::clamp(0.65 - frontend_result.metrics.visual_update_confidence * 0.30, 0.18, 0.65);
         (void)coordinator_->process_measurement(make_visual_pose_envelope(
             payload, MeasurementStamp{frame.timestamp, measurement_sequence_++}));
         submit_tracked_features_to_shadow(frontend_result, previous_camera_pose_, predicted_pose,
@@ -423,12 +455,15 @@ void VIOPipeline::handle(const sensors::LidarMeasurement& lidar) {
     std::vector<float> z_vals;
     z_vals.reserve(lidar.cloud->size());
     for (const auto& pt : *lidar.cloud) {
-        if (pt.z > -20.0f && pt.z < 0.5f) z_vals.push_back(pt.z);
+        if (pt.z > -20.0f && pt.z < 0.5f)
+            z_vals.push_back(pt.z);
     }
-    if (z_vals.empty()) return;
+    if (z_vals.empty())
+        return;
     const auto median_index = z_vals.size() / 2;
     std::nth_element(z_vals.begin(),
-                     z_vals.begin() + static_cast<std::vector<float>::difference_type>(median_index),
+                     z_vals.begin() +
+                         static_cast<std::vector<float>::difference_type>(median_index),
                      z_vals.end());
     const double ground_z = z_vals[median_index];
     const auto pose = coordinator_->active_pose();
@@ -447,7 +482,8 @@ void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
         std::lock_guard lock(visual_metrics_mutex_);
         metrics = last_visual_metrics_;
     }
-    if (metrics.visual_update_confidence <= 0.0) return;
+    if (metrics.visual_update_confidence <= 0.0)
+        return;
     pose.localization_confidence = std::clamp(
         pose.localization_confidence * std::clamp(metrics.visual_update_confidence, 0.18, 1.0), 0.0,
         1.0);
@@ -458,7 +494,8 @@ void VIOPipeline::apply_visual_quality_to_pose(PoseEstimate& pose) const {
         pose.localization_source =
             metrics.used_placeholder ? "simulation-placeholder-vision" : "low-visual-quality";
     }
-    if (pose.localization_confidence < 0.22) pose.localization_lost = true;
+    if (pose.localization_confidence < 0.22)
+        pose.localization_lost = true;
 }
 
 void VIOPipeline::set_estimator_validation_config(const EstimatorValidationConfig& cfg) {
@@ -472,13 +509,15 @@ void VIOPipeline::set_shadow_msckf_config(const MsckfConfig& cfg) {
 }
 
 void VIOPipeline::reconfigure_coordinator() {
-    if (!coordinator_) return;
+    if (!coordinator_)
+        return;
     coordinator_->configure_validation(estimator_validation_cfg_);
     coordinator_->configure_shadow_msckf(shadow_msckf_cfg_);
     coordinator_->stop();
     coordinator_->initialize();
     visual_feature_tracks_.reset();
-    if (running_.load()) (void)coordinator_->start();
+    if (running_.load())
+        (void)coordinator_->start();
 }
 
 double VIOPipeline::drift_m() const {
@@ -486,7 +525,8 @@ double VIOPipeline::drift_m() const {
 }
 
 void VIOPipeline::refresh_runtime_telemetry_from_coordinator() {
-    if (!coordinator_) return;
+    if (!coordinator_)
+        return;
     const auto diagnostics = coordinator_->diagnostics();
     std::lock_guard lock(runtime_mutex_);
     runtime_telemetry_.active_estimator_name = diagnostics.active_estimator_name;
@@ -499,8 +539,10 @@ void VIOPipeline::refresh_runtime_telemetry_from_coordinator() {
     runtime_telemetry_.shadow_queue_high_water_mark = diagnostics.queue.peak_depth;
     runtime_telemetry_.shadow_dropped_events = diagnostics.queue.dropped_count;
     runtime_telemetry_.shadow_position_delta_m = diagnostics.last_comparison.position_delta_norm_m;
-    runtime_telemetry_.shadow_velocity_delta_mps = diagnostics.last_comparison.velocity_delta_norm_mps;
-    runtime_telemetry_.shadow_orientation_delta_deg = diagnostics.last_comparison.orientation_delta_deg;
+    runtime_telemetry_.shadow_velocity_delta_mps =
+        diagnostics.last_comparison.velocity_delta_norm_mps;
+    runtime_telemetry_.shadow_orientation_delta_deg =
+        diagnostics.last_comparison.orientation_delta_deg;
     runtime_telemetry_.shadow_divergence_active =
         diagnostics.last_comparison.valid &&
         (diagnostics.last_comparison.position_delta_norm_m >

--- a/tests/test_msckf_marginalization.cpp
+++ b/tests/test_msckf_marginalization.cpp
@@ -51,8 +51,8 @@ TEST(MsckfMarginalizationTest, RetainedCovarianceIsExactPrincipalSubmatrix) {
     }
     const Eigen::MatrixXd P = (A * A.transpose()) + Eigen::MatrixXd::Identity(kDim, kDim);
 
-    const auto retained = MsckfMarginalization::retained_principal_submatrix(
-        P, kBaseDim, kCloneDim, clone_ids, 20u);
+    const auto retained =
+        MsckfMarginalization::retained_principal_submatrix(P, kBaseDim, kCloneDim, clone_ids, 20u);
     ASSERT_TRUE(retained.has_value());
     ASSERT_EQ(retained->rows(), 7);
     ASSERT_EQ(retained->cols(), 7);
@@ -60,9 +60,8 @@ TEST(MsckfMarginalizationTest, RetainedCovarianceIsExactPrincipalSubmatrix) {
     const std::vector<Eigen::Index> kept{0, 1, 2, 3, 4, 7, 8};
     for (Eigen::Index row = 0; row < retained->rows(); ++row) {
         for (Eigen::Index col = 0; col < retained->cols(); ++col) {
-            EXPECT_DOUBLE_EQ((*retained)(row, col),
-                             P(kept[static_cast<std::size_t>(row)],
-                               kept[static_cast<std::size_t>(col)]));
+            EXPECT_DOUBLE_EQ((*retained)(row, col), P(kept[static_cast<std::size_t>(row)],
+                                                      kept[static_cast<std::size_t>(col)]));
         }
     }
 }
@@ -77,8 +76,8 @@ TEST(MsckfMarginalizationTest, RetainedCrossCovariancesArePreserved) {
     P(4, 8) = -0.21;
     P(8, 4) = -0.21;
 
-    const auto retained = MsckfMarginalization::retained_principal_submatrix(
-        P, kBaseDim, kCloneDim, clone_ids, 20u);
+    const auto retained =
+        MsckfMarginalization::retained_principal_submatrix(P, kBaseDim, kCloneDim, clone_ids, 20u);
     ASSERT_TRUE(retained.has_value());
 
     EXPECT_DOUBLE_EQ((*retained)(0, 5), 0.37);
@@ -90,17 +89,15 @@ TEST(MsckfMarginalizationTest, RetainedCrossCovariancesArePreserved) {
 TEST(MsckfMarginalizationTest, InvalidCovarianceDimensionsFailClosed) {
     const std::vector<uint64_t> clone_ids{10u, 20u};
     const Eigen::MatrixXd bad = Eigen::MatrixXd::Identity(6, 6);
-    EXPECT_FALSE(MsckfMarginalization::retained_principal_submatrix(
-                     bad, 3u, 2u, clone_ids, 10u)
+    EXPECT_FALSE(MsckfMarginalization::retained_principal_submatrix(bad, 3u, 2u, clone_ids, 10u)
                      .has_value());
 }
 
 TEST(MsckfMarginalizationTest, MissingRetiringCloneFailsClosed) {
     const std::vector<uint64_t> clone_ids{10u, 20u};
     const Eigen::MatrixXd P = Eigen::MatrixXd::Identity(7, 7);
-    EXPECT_FALSE(MsckfMarginalization::retained_principal_submatrix(
-                     P, 3u, 2u, clone_ids, 30u)
-                     .has_value());
+    EXPECT_FALSE(
+        MsckfMarginalization::retained_principal_submatrix(P, 3u, 2u, clone_ids, 30u).has_value());
 }
 
 TEST(MsckfMarginalizationTest, CovarianceHealthAcceptsFiniteSymmetricPsdMatrix) {

--- a/tests/test_msckf_marginalization_integration.cpp
+++ b/tests/test_msckf_marginalization_integration.cpp
@@ -172,7 +172,8 @@ TEST(MsckfMarginalizationIntegration, RetiringClonePrunesOnlyItsFeatureObservati
     ASSERT_EQ(estimator.process_imu_measurement(Eigen::Vector3d{0.0, 0.0, 9.81},
                                                 Eigen::Vector3d::Zero(), 0.02),
               EstimatorOperationResult::Accepted);
-    const uint64_t second_id = Phase17ESKFEstimatorTestAccess::capture_msckf_camera_state(estimator);
+    const uint64_t second_id =
+        Phase17ESKFEstimatorTestAccess::capture_msckf_camera_state(estimator);
     ASSERT_EQ(second_id, 2u);
     ASSERT_TRUE(Phase17ESKFEstimatorTestAccess::process_msckf_observations(
         estimator, second_id, {pixel}, {feature}, camera_intrinsics()));
@@ -313,7 +314,8 @@ TEST(MsckfMarginalizationIntegration, RetirementConstraintPassDoesNotDuplicateCo
               EstimatorOperationResult::Accepted);
     pose = estimator.state();
     estimator.update_vision({project_feature(pose, feature, K)}, {feature}, K);
-    const uint64_t applied_after_second_observation = estimator.diagnostics().feature_updates_applied;
+    const uint64_t applied_after_second_observation =
+        estimator.diagnostics().feature_updates_applied;
 
     ASSERT_EQ(estimator.process_imu_measurement(Eigen::Vector3d{0.0, 0.0, 9.81},
                                                 Eigen::Vector3d::Zero(), 0.03),

--- a/tests/test_msckf_retirement_transaction.cpp
+++ b/tests/test_msckf_retirement_transaction.cpp
@@ -6,8 +6,8 @@ namespace drone::vio {
 namespace {
 
 Eigen::MatrixXd make_spd(std::size_t dim) {
-    Eigen::MatrixXd a = Eigen::MatrixXd::Zero(static_cast<Eigen::Index>(dim),
-                                              static_cast<Eigen::Index>(dim));
+    Eigen::MatrixXd a =
+        Eigen::MatrixXd::Zero(static_cast<Eigen::Index>(dim), static_cast<Eigen::Index>(dim));
     for (Eigen::Index i = 0; i < a.rows(); ++i) {
         a(i, i) = 2.0 + static_cast<double>(i) * 0.01;
         if (i + 1 < a.rows()) {
@@ -30,8 +30,8 @@ TEST(MsckfRetirementTransactionTest, RetiresOldestCloneAndPreservesPrincipalSubm
     EXPECT_EQ(result->retained_clone_ids, (std::vector<uint64_t>{12, 13}));
     ASSERT_EQ(result->retained_covariance.rows(), 27);
 
-    const auto expected = MsckfMarginalization::retained_principal_submatrix(
-        covariance, 15, 6, clones, 11);
+    const auto expected =
+        MsckfMarginalization::retained_principal_submatrix(covariance, 15, 6, clones, 11);
     ASSERT_TRUE(expected.has_value());
     EXPECT_LT((result->retained_covariance - *expected).norm(), 1.0e-12);
 }

--- a/tests/test_navigation_intelligence.cpp
+++ b/tests/test_navigation_intelligence.cpp
@@ -146,8 +146,7 @@ TEST(LocalizationFusion, InvalidTdoaPositionCannotRaiseConfidence) {
     input.time_sync.synchronized = true;
 
     localization::TDOALocalizer::Solution tdoa_solution;
-    tdoa_solution.position =
-        Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    tdoa_solution.position = Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
     tdoa_solution.confidence = 1.0;
     input.tdoa_solution = tdoa_solution;
 

--- a/tests/test_shadow_only_measurement.cpp
+++ b/tests/test_shadow_only_measurement.cpp
@@ -139,9 +139,8 @@ TEST(ShadowOnlyMeasurement, FeatureSubmissionNeverTouchesActiveEstimator) {
 }
 
 TEST(ShadowOnlyMeasurement, InvalidEnvelopeFailsBeforeQueuePublication) {
-    EstimatorCoordinator coordinator(
-        std::make_unique<EKFStateEstimatorAdapter>(),
-        std::make_unique<RecordingShadowEstimator>());
+    EstimatorCoordinator coordinator(std::make_unique<EKFStateEstimatorAdapter>(),
+                                     std::make_unique<RecordingShadowEstimator>());
     coordinator.configure_validation(shadow_cfg(true));
     coordinator.initialize();
     ASSERT_TRUE(coordinator.start());
@@ -159,9 +158,8 @@ TEST(ShadowOnlyMeasurement, InvalidEnvelopeFailsBeforeQueuePublication) {
 }
 
 TEST(ShadowOnlyMeasurement, DisabledShadowFailsClosedWithoutActiveMutation) {
-    EstimatorCoordinator coordinator(
-        std::make_unique<EKFStateEstimatorAdapter>(),
-        std::make_unique<RecordingShadowEstimator>());
+    EstimatorCoordinator coordinator(std::make_unique<EKFStateEstimatorAdapter>(),
+                                     std::make_unique<RecordingShadowEstimator>());
     coordinator.configure_validation(shadow_cfg(false));
     coordinator.initialize();
 

--- a/tests/test_visual_feature_track_manager.cpp
+++ b/tests/test_visual_feature_track_manager.cpp
@@ -70,7 +70,8 @@ TEST(VisualFeatureTrackManager, InvalidInputFailsClosedAndClearsTransientTracks)
     ASSERT_EQ(manager.track_count(), 1u);
 
     const std::vector<Eigen::Vector2d> mismatched{{312.0, 240.0}, {300.0, 220.0}};
-    const auto rejected = manager.update(previous, mismatched, pose_at(0.10), pose_at(0.20), intrinsics());
+    const auto rejected =
+        manager.update(previous, mismatched, pose_at(0.10), pose_at(0.20), intrinsics());
     EXPECT_TRUE(rejected.features.empty());
     EXPECT_EQ(manager.track_count(), 0u);
 }

--- a/tests/visual_feature_track_ingest_replay.cpp
+++ b/tests/visual_feature_track_ingest_replay.cpp
@@ -84,8 +84,8 @@ ReplayResult run_once() {
         if (payload.z_pixels.empty()) {
             return false;
         }
-        return coordinator.submit_shadow_measurement(make_visual_features_envelope(
-                   payload, MeasurementStamp{timestamp, sequence})) ==
+        return coordinator.submit_shadow_measurement(
+                   make_visual_features_envelope(payload, MeasurementStamp{timestamp, sequence})) ==
                EstimatorOperationResult::Accepted;
     };
 


### PR DESCRIPTION
Validation PR for the remaining CI repairs on `fix/ci-resolve`.

Includes:
- exact clang-format repairs across the failing C++ files
- MSVC retirement iterator safety fix
- diagnostic workflow actionlint hardening

Do not merge until all CI and Security checks are green.