### PR TITLE
Fix Python formatting and static analysis

### DIFF
--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -19,6 +19,7 @@ runs:
           golang-go \
           libeigen3-dev \
           libopencv-dev \
+          libomp-dev \
           libpcl-dev \
           libspdlog-dev \
           libopenmpi-dev \

--- a/.github/workflows/black-diagnostic.yml
+++ b/.github/workflows/black-diagnostic.yml
@@ -1,0 +1,36 @@
+name: Black Diagnostic
+
+on:
+  push:
+    branches:
+      - fix/ci-python-static-analysis
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  black:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Install CI Black
+        run: python3 -m pip install black==24.10.0
+      - name: Capture Black diff for existing Python trees
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
+          set -o pipefail
+          black --check --diff --color scripts tools 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/black.log"
+      - name: Upload Black diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: black-existing-trees-${{ github.sha }}
+          path: ${{ runner.temp }}/ci-diagnostic/black.log
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/black-diagnostic.yml
+++ b/.github/workflows/black-diagnostic.yml
@@ -20,17 +20,17 @@ jobs:
           python-version: "3.14"
       - name: Install CI Black
         run: python3 -m pip install black==24.10.0
-      - name: Capture Black diff for existing Python trees
+      - name: Capture production Black diff
         shell: bash
         run: |
           mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
           set -o pipefail
-          black --check --diff --color scripts tools 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/black.log"
+          python3 -m black --check --diff main.py gui tests scripts 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/black.log"
       - name: Upload Black diagnostic log
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: black-existing-trees-${{ github.sha }}
+          name: black-production-targets-${{ github.sha }}
           path: ${{ runner.temp }}/ci-diagnostic/black.log
           if-no-files-found: error
           retention-days: 3

--- a/.github/workflows/ci-diagnostic.yml
+++ b/.github/workflows/ci-diagnostic.yml
@@ -1,6 +1,9 @@
 name: CI Diagnostic
 
 on:
+  push:
+    branches:
+      - fix/ci-python-static-analysis
   pull_request:
     branches:
       - main
@@ -69,6 +72,33 @@ jobs:
           name: clang-format-${{ github.sha }}
           path: ${{ runner.temp }}/ci-diagnostic/clang-format.log
           if-no-files-found: warn
+          retention-days: 3
+
+  python-formatting-diagnostic:
+    name: Python Formatting Diagnostic
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Install CI Black
+        shell: bash
+        run: python3 -m pip install black==24.10.0
+      - name: Capture Black output
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/ci-diagnostic"
+          set -o pipefail
+          black --check --diff --color python/src python/tests scripts tools 2>&1 | tee "${RUNNER_TEMP}/ci-diagnostic/black.log"
+      - name: Upload Black diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: black-${{ github.sha }}
+          path: ${{ runner.temp }}/ci-diagnostic/black.log
+          if-no-files-found: error
           retention-days: 3
 
   static-analysis-diagnostic:


### PR DESCRIPTION
Repair the two remaining failing main checks from run 32965329195: Python Black formatting and clang-tidy static analysis. This PR stays draft while fixes are being validated; do not merge until all CI/security checks are green.