### PR TITLE
fix(tests): link localization metadata regression against core

### DIFF
--- a/tests/visual_feature_track_ingest.cmake
+++ b/tests/visual_feature_track_ingest.cmake
@@ -65,10 +65,10 @@ set_tests_properties(visual_feature_track_ingest_replay PROPERTIES
 
 add_executable(test_localization_metadata_fail_closed
     "${CMAKE_CURRENT_LIST_DIR}/test_localization_metadata_fail_closed.cpp"
-    "${PROJECT_SOURCE_DIR}/src/localization/LocalizationFusion.cpp"
 )
 target_link_libraries(test_localization_metadata_fail_closed PRIVATE
     drone_test_support
+    sensor_fusion_core
     Eigen3::Eigen
 )
 drone_apply_project_warnings(test_localization_metadata_fail_closed)


### PR DESCRIPTION
## Summary

Fixes the build wiring for the non-finite localization metadata regression target.

The dedicated test previously compiled `LocalizationFusion.cpp` directly, bypassing the repository's established core target wiring. This caused GCC/Debug/Validation and Full Validator build failures.

This change:
- removes direct compilation of `src/localization/LocalizationFusion.cpp`
- links `test_localization_metadata_fail_closed` against `sensor_fusion_core`
- keeps the permanent fail-closed regression coverage unchanged

No production localization behavior changes.