### PR TITLE
ci: verify finalized localization hardening

### DIFF
--- a/tests/test_localization_metadata_fail_closed.cpp
+++ b/tests/test_localization_metadata_fail_closed.cpp
@@ -36,6 +36,7 @@ void expect_metadata_fail_closed(const localization::LocalizationFusionOutput& o
 } // namespace
 
 // Non-finite localization metadata must never leave the fused state nominal.
+// This dedicated target also keeps the safety invariant visible in full CI.
 TEST(LocalizationFusionMetadata, NonFiniteAnchorVisibilityFailsClosed) {
     localization::LocalizationFusion fusion;
     auto input = make_nominal_input();


### PR DESCRIPTION
Validation-only PR for the finalized localization metadata fail-closed hardening currently on `main`. The only branch delta is a non-functional test comment so the full pull-request CI matrix can run without changing production behavior. Do not merge; close after all required checks complete.